### PR TITLE
test-runner fix (Option A)

### DIFF
--- a/.github/workflows/auto-spiral.yml
+++ b/.github/workflows/auto-spiral.yml
@@ -17,6 +17,7 @@ jobs:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: pnpm i --frozen-lockfile
+      - run: pnpm test
       - run: pnpm ts-node scripts/pregen.ts 10000
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "libs/*"
   ],
   "scripts": {
-    "test": "pnpm -r test",
+    "test": "pnpm -r exec jest",
     "dev": "pnpm --filter microsite dev"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- fix Jest runner so `pnpm test` uses `pnpm -r exec jest`
- run tests in the CI workflow

## Testing
- `pnpm install --frozen-lockfile` *(fails: lockfile missing)*
- `pnpm test` *(fails: command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bd3763288327b3808bf3afe9a949