### PR TITLE
Add phi milestone utilities

### DIFF
--- a/data/world_events.csv
+++ b/data/world_events.csv
@@ -1,2 +1,3 @@
 date,title,locale
 1970-01-01,Unix epoch begins,Global
+1971-08-14,Event near phi milestone,US

--- a/libs/spiral-math/__tests__/index.test.ts
+++ b/libs/spiral-math/__tests__/index.test.ts
@@ -1,4 +1,12 @@
-import { birthdateToNode } from '../index';
+import fs from 'fs';
+import path from 'path';
+import { parse } from 'csv-parse/sync';
+import {
+  birthdateToNode,
+  phiMilestones,
+  milestoneEvents,
+  HarmonicEvent
+} from '../index';
 
 test('epoch date hits node 88', () => {
   expect(birthdateToNode(new Date('1970-01-01'))).toBe(88);
@@ -6,4 +14,20 @@ test('epoch date hits node 88', () => {
 
 test('2000-01-01 is within range', () => {
   expect(birthdateToNode(new Date('2000-01-01'))).not.toBe(0);
+});
+
+test('phi milestone calculation', () => {
+  const ms = phiMilestones(new Date('1970-01-01'), 1);
+  expect(ms[0].date).toBe('1971-08-15');
+});
+
+test('milestone events picks nearby csv rows', () => {
+  const csv = fs.readFileSync(
+    path.join(__dirname, '../../../data/world_events.csv'),
+    'utf8'
+  );
+  const events = parse(csv, { columns: true }) as HarmonicEvent[];
+  const result = milestoneEvents(new Date('1970-01-01'), events, 1);
+  expect(result[0].events.length).toBe(1);
+  expect(result[0].events[0].title).toBe('Event near phi milestone');
 });

--- a/libs/spiral-math/index.ts
+++ b/libs/spiral-math/index.ts
@@ -21,3 +21,32 @@ export function calcHarmonicEvents(bd: Date, events: HarmonicEvent[]): HarmonicE
   );
   return events.filter(ev => window.includes(ev.date));
 }
+
+export interface PhiMilestone {
+  n: number;
+  date: string;
+}
+
+export function phiMilestones(bd: Date, steps = 12): PhiMilestone[] {
+  const out: PhiMilestone[] = [];
+  for (let i = 1; i <= steps; i++) {
+    const days = Math.round(Math.pow(PHI, i) * 365.25);
+    const date = new Date(bd.getTime() + days * 86400000)
+      .toISOString()
+      .substring(0, 10);
+    out.push({ n: i, date });
+  }
+  return out;
+}
+
+export function milestoneEvents(
+  bd: Date,
+  events: HarmonicEvent[],
+  steps = 12
+): { milestone: PhiMilestone; events: HarmonicEvent[] }[] {
+  const milestones = phiMilestones(bd, steps);
+  return milestones.map(m => ({
+    milestone: m,
+    events: calcHarmonicEvents(new Date(m.date), events)
+  }));
+}


### PR DESCRIPTION
## Summary
- extend `spiral-math` with phi milestone helpers
- expand example world events data
- test milestone calculation and event lookup

## Testing
- `pnpm test` *(fails: Command "jest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ecca8d588327938dcd5864e9e442