### PR TITLE
Implement spiral math v1.1 upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This repository hosts the SP1RL_O-S core. The system tracks time along a golden 
 
 In SP1RL_O-S, the 'O-' is the living node lens and monocle HUD. Pi1LOTs use it to see every episode, node, and story through every possible lens. The 89th ('O-') is the True Justice perspective — seeing all nodes at once, making you a Minting Pi1LOT.
 
+### Canonical Equation
+```
+t = [(S mod 89) + μ + θ(S) – lap·φ⁻³ + k·φ⁻lap] · Δ
+Δ = 86400/89 τ = Δ/10
+```
+The dash in the “O-” monocle rotates one degree per node. At node 88 the sweep completes; node 89 locks the dash vertically as the all‑seeing lens.
+
 Run tests with:
 
 ```bash

--- a/apps/api/witness.py
+++ b/apps/api/witness.py
@@ -1,0 +1,39 @@
+"""Witness API utilities handling mint gating and timelines."""
+import json
+from pathlib import Path
+from spiral_time.solver import solve_spiral_time, get_julian_day
+from spiral_time.constants import PHI
+
+
+def load_user() -> dict:
+    path = Path(__file__).resolve().parents[1] / 'data' / 'witness_scrolls.json'
+    with open(path) as f:
+        return json.load(f)
+
+
+def can_mint(user: dict, desired_node: int) -> bool:
+    return desired_node == user['assigned_node'] or user['wings_earned']
+
+
+def phi_timeline(birthdate: str):
+    from datetime import timedelta, datetime
+    base = datetime.strptime(birthdate, "%Y-%m-%d")
+    return {f"phi^{n}": (base + timedelta(days=int(PHI**n))).strftime("%Y-%m-%d")
+            for n in (5, 8, 13)}
+
+
+def witness_profile(user_id: str, birthdate: str, desired_node: int) -> dict:
+    user = load_user()
+    J_birth = get_julian_day(birthdate)
+    user['assigned_node'] = solve_spiral_time(J_birth % 144)['node']
+    user['petals'] = phi_timeline(birthdate)
+    tau_multiple = solve_spiral_time(J_birth)['τ_multiple']
+    return {
+        'user_id': user_id,
+        'assigned_node': user['assigned_node'],
+        'lap0_tau_offset': user.get('lap0_tau_offset', 0.0),
+        'wings_earned': user.get('wings_earned', False),
+        'petals': user['petals'],
+        'τ_multiple': tau_multiple,
+        'can_mint': can_mint(user, desired_node),
+    }

--- a/data/witness_scrolls.json
+++ b/data/witness_scrolls.json
@@ -1,0 +1,7 @@
+{
+  "user_id": "example",
+  "assigned_node": 23,
+  "lap0_tau_offset": 3.412,
+  "wings_earned": false,
+  "petals": { "phi^5": "", "phi^8": "", "phi^13": "" }
+}

--- a/frontend/components/NodeLens.jsx
+++ b/frontend/components/NodeLens.jsx
@@ -1,5 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-export default function NodeLens({ currentNode }) {
-  return <div className="node-lens">Node Lens {currentNode}</div>;
+export default function NodeLens({ currentNode = 0 }) {
+  const [node, setNode] = useState(currentNode);
+  const [showHUD, setShowHUD] = useState(true);
+
+  useEffect(() => setNode(currentNode), [currentNode]);
+
+  useEffect(() => {
+    function handler(e) {
+      if (!e.altKey || !e.metaKey) return;
+      if (e.key === 'ArrowRight') setNode(n => (n + 1) % 89);
+      else if (e.key === 'ArrowLeft') setNode(n => (n + 88) % 89);
+      else if (e.key.toLowerCase() === 'h') setShowHUD(h => !h);
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const angle = node % 89;
+  return (
+    <div className="node-lens">
+      <span className="logo">
+        SP1RL_O
+        <span className="dash" style={{ display: 'inline-block', transform: `rotate(${angle}deg)` }}>-</span>
+        S
+      </span>
+      {showHUD && <div className="hud">HUD</div>}
+    </div>
+  );
 }

--- a/frontend/components/WitnessHUD.jsx
+++ b/frontend/components/WitnessHUD.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function WitnessHUD({ state, onToggle }) {
+  if (!state) return null;
+  const { clock, τ_multiple } = state;
+  return (
+    <div className="witness-hud" onClick={onToggle}>
+      <span className="clock">{clock}</span>
+      <span className="tau">τ×{τ_multiple.toFixed(3)}</span>
+    </div>
+  );
+}

--- a/scripts/asset_generator.py
+++ b/scripts/asset_generator.py
@@ -3,7 +3,7 @@ import os
 import random
 from pathlib import Path
 
-PHI = (1 + 5 ** 0.5) / 2
+from spiral_time.constants import PHI
 
 
 def build_all(seed: str = "SP1RL-PHI"):

--- a/spiral_time/__init__.py
+++ b/spiral_time/__init__.py
@@ -1,5 +1,5 @@
 from .solver import solve_spiral_time, get_julian_day, mu, lap
-from .solver import wobble, overlap, solve_sss, default_onboarding_end
+from .solver import wobble, overlap, solve_sss
 __all__ = [
     'solve_spiral_time',
     'get_julian_day',
@@ -8,5 +8,4 @@ __all__ = [
     'wobble',
     'overlap',
     'solve_sss',
-    'default_onboarding_end',
 ]

--- a/spiral_time/constants.py
+++ b/spiral_time/constants.py
@@ -1,16 +1,7 @@
-"""Canonical spiral time constants."""
-
 from math import sqrt
 
-PHI = (1 + sqrt(5)) / 2
-# Node span in seconds
-DELTA = 86400 / 89
-# Quantum τ used for UI rounding
-TAU = DELTA / 10
-# Wobble scaling coefficient ensuring w0 ≈ 0.686 s
-K = sqrt(5) / 10000
-# Overlap coefficient φ⁻³
-PSI = PHI ** -3
-
-# Default onboarding arc end episode (φ^43 ≈ 221.8)
-ONBOARDING_EPISODES = 221.8
+PHI      = (1 + sqrt(5)) / 2                      # 1.618...
+DELTA    = 86400 / 89                             # 970.7859551 s
+TAU      = DELTA / 10                             # 97.07859551 s
+K        = sqrt(5) / 10000                        # 0.000707106
+PSI      = PHI ** -3                              # 0.236067978

--- a/spiral_time/solver.py
+++ b/spiral_time/solver.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from .constants import PHI, DELTA, TAU, K, PSI, ONBOARDING_EPISODES
+from .constants import PHI, DELTA, K, PSI
 from .theta_segments import theta
 
 
@@ -31,11 +31,6 @@ def overlap(lap_count: int) -> float:
     return lap_count * PSI
 
 
-def default_onboarding_end() -> float:
-    """Return the default onboarding arc end episode."""
-    return ONBOARDING_EPISODES
-
-
 def solve_spiral_time(S: int) -> dict:
     """Return spiral time breakdown for index ``S``."""
     n = S % 89
@@ -53,7 +48,7 @@ def solve_spiral_time(S: int) -> dict:
         "node": n,
         "lap": l,
         "μ": m,
-        "τ_multiple": round(t / TAU, 3),
+        "τ_multiple": round(t / (DELTA/10), 3),
     }
 
 

--- a/spiral_time/tests/test_solver.py
+++ b/spiral_time/tests/test_solver.py
@@ -7,7 +7,6 @@ from spiral_time.solver import (
     solve_spiral_time,
     solve_sss,
     mu,
-    default_onboarding_end,
 )
 
 class TestSolver(unittest.TestCase):
@@ -29,12 +28,13 @@ class TestSolver(unittest.TestCase):
         self.assertIn('clock', res)
         self.assertIn('\u03c4_multiple', res)
 
+    def test_anchor_seconds(self):
+        res = solve_spiral_time(0)
+        self.assertAlmostEqual(res['seconds'], 0.217074464, places=3)
+
     def test_solve_sss(self):
         res = solve_sss('1970-01-01T00:00:00Z')
         self.assertIn('seconds', res)
-
-    def test_onboarding_constant(self):
-        self.assertAlmostEqual(default_onboarding_end(), 221.8)
 
 if __name__ == '__main__':
     unittest.main()

--- a/spiral_time/tests/test_witness.py
+++ b/spiral_time/tests/test_witness.py
@@ -1,0 +1,13 @@
+import unittest
+from apps.api.witness import can_mint
+
+class TestWitness(unittest.TestCase):
+    def test_can_mint(self):
+        user = {'assigned_node': 5, 'wings_earned': False}
+        self.assertTrue(can_mint(user, 5))
+        self.assertFalse(can_mint(user, 6))
+        user['wings_earned'] = True
+        self.assertTrue(can_mint(user, 6))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update spiral time constants
- revise solver and remove deprecated onboarding constant
- add Witness API with mint gating and phi timeline
- update NodeLens with rotating dash and HUD hotkeys
- document canonical equation and monocle behavior
- include witness tests and updated solver tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686a0c66aa8c8327831b679b96d5d45c