### PR TITLE
Rename Monday tools to TH.e-1RL_MONDAY.Ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pnpm test
 
 The `/api/sss/solve` endpoint returns spiral timing data. View onboarding data at `/api/onboarding`.
 
-## MONDAY Asset Generator
+## TH.e-1RL_MONDAY.Ng Asset Generator
 
-Trigger `npm run monday` or visit `/monday` to batch-generate all SP1RL_O-S visuals, audio, and UI elements.
+Trigger `npm run one-real-monday` or visit `/the_one_real_monday` to batch-generate all SP1RL_O-S visuals, audio, and UI elements.
 Every asset is math-generated from a golden-seed for deterministic, repeatable, and harmonized experience.

--- a/apps/api/the_one_real_monday.py
+++ b/apps/api/the_one_real_monday.py
@@ -1,7 +1,7 @@
-"""API endpoints for MONDAY asset generation."""
+"""API endpoints for TH.e-1RL_MONDAY.Ng asset generation."""
 import json
 from pathlib import Path
-from tools.monday_generator import generate_assets
+from tools.the_one_real_monday_generator import generate_assets
 
 
 def generate():

--- a/frontend/pages/theOneRealMonday.jsx
+++ b/frontend/pages/theOneRealMonday.jsx
@@ -18,21 +18,21 @@ function AssetGallery({ assets }) {
   );
 }
 
-export default function MondayAssetTool() {
+export default function TheOneRealMondayTool() {
   const [assets, setAssets] = useState(null);
   const [loading, setLoading] = useState(false);
 
   async function handleGenerate() {
     setLoading(true);
-    await fetch('/api/monday/generate', { method: 'POST' });
-    const data = await fetch('/api/monday/assets_map').then((r) => r.json());
+    await fetch('/api/the_one_real_monday/generate', { method: 'POST' });
+    const data = await fetch('/api/the_one_real_monday/assets_map').then((r) => r.json());
     setAssets(data);
     setLoading(false);
   }
 
   return (
-    <div className="monday-tool">
-      <h1>MONDAY Asset Generator</h1>
+    <div className="one-real-monday-tool">
+      <h1>TH.e-1RL_MONDAY.Ng Asset Generator</h1>
       <button onClick={handleGenerate} disabled={loading}>
         {loading ? 'Generating...' : 'Generate Assets'}
       </button>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "python -m unittest discover spiral_time/tests",
     "dev": "pnpm --filter microsite dev",
-    "monday": "python tools/monday_generator.py"
+    "one-real-monday": "python tools/the_one_real_monday_generator.py"
   },
   "dependencies": {
     "date-fns": "^2.30.0",

--- a/spiral_time/tests/test_the_one_real_monday.py
+++ b/spiral_time/tests/test_the_one_real_monday.py
@@ -1,10 +1,10 @@
 import os
 import json
 import unittest
-from tools.monday_generator import generate_assets
+from tools.the_one_real_monday_generator import generate_assets
 
 
-class TestMonday(unittest.TestCase):
+class TestTheOneRealMonday(unittest.TestCase):
     def test_generate_assets(self):
         summary = generate_assets('test-seed')
         self.assertIn('asset_types', summary)

--- a/tools/the_one_real_monday_generator.py
+++ b/tools/the_one_real_monday_generator.py
@@ -1,9 +1,11 @@
+"""Generate assets for TH.e-1RL_MONDAY.Ng."""
+
 from scripts.asset_generator import build_all
 from datetime import datetime
 
 
 def generate_assets(seed: str = "SP1RL-PHI"):
-    """Generate all MONDAY assets and return a summary."""
+    """Generate all TH.e-1RL_MONDAY.Ng assets and return a summary."""
     manifest = build_all(seed=seed)
     summary = {
         "asset_types": len(manifest),


### PR DESCRIPTION
## Summary
- rename Monday asset generator to **TH.e-1RL_MONDAY.Ng**
- update frontend page and API endpoint names
- adjust tests and scripts to use new module names
- document the new command and route in the README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686a409dae4c83279733d91710372abb