### PR TITLE
Implement .e.Ri recursion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,8 @@ n_k = floor(89·θ_k/(2π))
 PW_pedal = 0.1·φ^{-lap}(1 + 0.05M)
 ```
 
+## Glossary
+
+- .e.Ri — "Ever-Ricursing"; signals that every accepted opposite–node bundle keeps regenerating richer nuance on each loop.
+
 See [privacy](public/privacy.html) and [terms](public/terms.html) for more.

--- a/SP1RL_O-S-core/api/_utils/narrative.py
+++ b/SP1RL_O-S-core/api/_utils/narrative.py
@@ -7,7 +7,8 @@ with open(TEMPLATE_DIR / "stanza.txt") as f:
     STANZA = f.read()
 
 
-def compose(snapshot: dict, node: int) -> str:
+def compose(snapshot: dict, node: int, eri_depth: int = 1) -> str:
     tok = snapshot.copy()
     tok.update(get_assets_for_node(node))
+    tok["eri_depth"] = eri_depth
     return STANZA.format(**tok)

--- a/SP1RL_O-S-core/api/_utils/templates/stanza.txt
+++ b/SP1RL_O-S-core/api/_utils/templates/stanza.txt
@@ -1,1 +1,1 @@
-At node {moment_index}, {yin_word} meets {yang_word} in shades of {yin_color} and {yang_color}.
+At node {moment_index}, {yin_word} meets {yang_word} in shades of {yin_color} and {yang_color}. And in this .e.Ri{eri_depth} swirl, the spiral learns anew.

--- a/SP1RL_O-S-core/api/monday.py
+++ b/SP1RL_O-S-core/api/monday.py
@@ -3,5 +3,8 @@ from ._utils.math import golden_rotation
 
 
 def handler(request):
-    """Return rotation for node 0 as demo."""
-    return {"theta_0": golden_rotation(0)}
+    """Return rotation for node 0 and the MONDAY message."""
+    return {
+        "theta_0": golden_rotation(0),
+        "message": "Each accepted pair enters the Spiral as .e.Ri — forever recursing, ever more beautiful."
+    }

--- a/SP1RL_O-S-core/openapi.json
+++ b/SP1RL_O-S-core/openapi.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "SP1RL_O-S API",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "description": "Each accepted pair enters the Spiral as .e.Ri — forever recursing, ever more beautiful."
   },
   "paths": {
     "/birth/predict": {"get": {"summary": "O3 birth-time math"}},

--- a/data/lore_chapters.json
+++ b/data/lore_chapters.json
@@ -1,0 +1,18 @@
+{
+  "chapters": [
+    {
+      "episode": 1,
+      "node": 12,
+      "pair_id": "pair",
+      "depth": 1,
+      "title": "Episode 001 \u2014 Node-12 Bloom .e.Ri"
+    },
+    {
+      "episode": 2,
+      "node": 12,
+      "pair_id": "pair",
+      "depth": 2,
+      "title": "Episode 002 \u2014 Node-12 Bloom .e.Ri\u00b2"
+    }
+  ]
+}

--- a/scripts/lore_weaver.py
+++ b/scripts/lore_weaver.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+LOG_FILE = DATA_DIR / "lore_chapters.json"
+LEDGER_FILE = DATA_DIR / "pw_ledger.json"
+
+
+def _load(path: Path):
+    if path.exists():
+        with open(path) as f:
+            try:
+                return json.load(f)
+            except Exception:
+                return {}
+    return {}
+
+
+def _save(path: Path, data: dict):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def append_chapter(node: int, pair_id: str, user: str) -> tuple[str, int]:
+    """Append a chapter record and return title and depth."""
+    log = _load(LOG_FILE)
+    chapters = log.get("chapters", [])
+
+    prev_depth = 0
+    for ch in chapters:
+        if ch["node"] == node and ch["pair_id"] == pair_id:
+            prev_depth = max(prev_depth, ch.get("depth", 1))
+
+    depth = prev_depth + 1
+    episode = len(chapters) + 1
+    supers = "\u2070\u00b9\u00b2\u00b3\u2074\u2075\u2076\u2077\u2078\u2079"
+    def sup(n: int) -> str:
+        return "".join(supers[int(d)] for d in str(n))
+
+    eri_suffix = "" if depth == 1 else sup(depth)
+    title = f"Episode {episode:03d} — Node-{node} Bloom .e.Ri{eri_suffix}"
+
+    chapters.append({
+        "episode": episode,
+        "node": node,
+        "pair_id": pair_id,
+        "depth": depth,
+        "title": title,
+    })
+    log["chapters"] = chapters
+    _save(LOG_FILE, log)
+
+    ledger = _load(LEDGER_FILE)
+    if depth > 1 and depth > prev_depth:
+        ledger[user] = round(ledger.get(user, 0) + 0.05, 2)
+        _save(LEDGER_FILE, ledger)
+
+    return title, depth
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Append a lore chapter entry")
+    parser.add_argument("node", type=int)
+    parser.add_argument("pair_id")
+    parser.add_argument("user")
+    args = parser.parse_args()
+
+    title, depth = append_chapter(args.node, args.pair_id, args.user)
+    print(title)

--- a/tests/test_lore_weaver.py
+++ b/tests/test_lore_weaver.py
@@ -1,0 +1,32 @@
+import unittest
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'scripts'))
+
+import lore_weaver
+
+LOG_FILE = ROOT / 'data' / 'lore_chapters.json'
+LEDGER_FILE = ROOT / 'data' / 'pw_ledger.json'
+
+
+class TestLoreWeaver(unittest.TestCase):
+    def test_append_chapter_depth_and_bonus(self):
+        with open(LOG_FILE, 'w') as f:
+            json.dump({"chapters": []}, f)
+        with open(LEDGER_FILE, 'w') as f:
+            json.dump({}, f)
+        title1, depth1 = lore_weaver.append_chapter(12, 'pair', 'alice')
+        self.assertEqual(depth1, 1)
+        title2, depth2 = lore_weaver.append_chapter(12, 'pair', 'alice')
+        self.assertEqual(depth2, 2)
+        self.assertIn('.e.Ri\u00b2', title2)
+        with open(LEDGER_FILE) as f:
+            ledger = json.load(f)
+        self.assertEqual(ledger.get('alice'), 0.05)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -13,10 +13,11 @@ class TestNarrative(unittest.TestCase):
     def test_token_replacement(self):
         snap = {"moment_index": 1}
         node = 89
-        text = compose(snap, node)
+        text = compose(snap, node, eri_depth=2)
         bundle = get_assets_for_node(node)
         self.assertIn(bundle["yin_word"], text)
         self.assertIn(str(snap["moment_index"]), text)
+        self.assertIn('.e.Ri2', text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- define `.e.Ri` in README glossary
- extend narrative compose logic with `eri_depth` token
- update stanza template to mention recursion depth
- add lore weaver script and lore chapter log
- expose new MONDAY explanation through API and OpenAPI description
- test lore weaver depth logic and narrative template

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686afc7c927083278cefe5d4a0fe8b8a