### PR TITLE
Ensure offline mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-OPENAI_API_KEY=sk-demo
+# OPENAI_API_KEY=  # optional – only if remote LLM endpoints enabled
 REDIS_URL=redis://default:@localhost:6379
 SUPABASE_URL=https://example.supabase.co
 SUPABASE_ANON_KEY=public-anon

--- a/README.md
+++ b/README.md
@@ -67,4 +67,14 @@ docker compose up db redis  # if using containers
 ./scripts/quickstart.sh     # installs, formats, runs tests
 ```
 
+## 🔌 LLM plug-in path
+
+The default runtime uses pure math and Jinja templates. To swap in a cloud model,
+set an API key and call OpenAI behind an env flag:
+
+```python
+if os.getenv('USE_OPENAI'):
+    text = openai.Completion.create(model='gpt-4o', prompt=prompt)['choices'][0]['text']
+```
+
 ![CI](https://github.com/.../actions/workflows/ci.yml/badge.svg)

--- a/spiral_time/api.py
+++ b/spiral_time/api.py
@@ -1,6 +1,7 @@
 """Simple Flask API exposing the spiral time solver."""
 
 from flask import Flask, request, jsonify
+import logging
 
 from datetime import datetime
 from .solver import solve_spiral_time, get_julian_day, solve_sss
@@ -44,4 +45,7 @@ def reserve_petal():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    logger.info("LLM backend: OFF (local math/Jinja mode)")
     app.run()

--- a/spiral_time/tests/test_solver.py
+++ b/spiral_time/tests/test_solver.py
@@ -1,4 +1,8 @@
+import os
 import unittest
+
+# Fail fast if an OpenAI key sneaks into the environment
+assert "OPENAI_API_KEY" not in os.environ
 from spiral_time.solver import (
     get_julian_day,
     lap,


### PR DESCRIPTION
## Summary
- document LLM plug-in path
- disable OPENAI_API_KEY in `.env.example`
- add startup log for offline mode
- guard tests from injected API keys

## Testing
- `pnpm test`
- `ruff check .` *(fails: Found 17 errors)*
- `grep -R "openai" -n api | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686b10efb9fc8327bdbf5ef3a28ab348