### PR TITLE
Fix lint job and pin Python tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,16 @@ env:
   PNPM_VERSION: "9"
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint sweep
+        run: ./scripts/ci_sweep.sh
+
   preview:
     if: github.event_name == 'pull_request'
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +48,7 @@ jobs:
 
   deploy:
     if: github.event_name == 'push'
+    needs: lint
     runs-on: ubuntu-latest
     environment: production
     env:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
 jinja2==3.1.3
 schemathesis==3.15.3
 ruff==0.4.4
+black==24.4.2
+mypy==1.10.0

--- a/scripts/ci_sweep.sh
+++ b/scripts/ci_sweep.sh
@@ -1,30 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- bootstrap -------------------------------------------------
-# Ensure Ruff is available (avoids “command not found” in GH runner)
-python - <<'PY'
-import importlib, subprocess, sys
-try:
-    importlib.import_module("ruff")
-except ModuleNotFoundError:
-    subprocess.check_call([
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--quiet",
-        "ruff==0.4.4",
-    ])
-PY
-
-# Pin Ruff version used in CI runs
-pip install --quiet ruff==0.4.4
-
 # --- Lint & type-check sweep -----------------------------------
-echo "🔍  Ruff…"      && ruff check .
-echo "🧹  Black…"     && black  --check .
-echo "🔠  MyPy…"      && mypy   .
+echo "🔍 Ruff…"
+ruff check .
+
+echo "🧹 Black…"
+# Ensure Black is available even in fresh runners
+python -m pip install --quiet black==24.4.2
+black --check .
+
+echo "🔤 MyPy…"
+python -m pip install --quiet mypy==1.10.0
+mypy .
+
+echo "✅ All checks passed!"
 
 # --- JS/TS workspace lint (optional) ---------------------------
 # pnpm dlx eslint . --max-warnings 0


### PR DESCRIPTION
## Summary
- add lint job before deploy jobs
- pin linting tool versions in `requirements-test.txt`
- make `ci_sweep.sh` hermetic by installing Black & MyPy

## Testing
- `bash scripts/ci_sweep.sh` *(fails: Could not fetch black due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_686be32efc24832795394dde60a6444c