### PR TITLE
Fix CI sweep to install lint deps

### DIFF
--- a/scripts/ci_sweep.sh
+++ b/scripts/ci_sweep.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ---- lint deps ---------------------------------------------------------
+python -m pip install --quiet ruff==0.4.4 black==24.4.2
+
 # --- Lint & type-check sweep -----------------------------------
 echo "🔍 Ruff…"
 ruff check .
 
 echo "🧹 Black…"
-# Ensure Black is available even in fresh runners
-python -m pip install --quiet black==24.4.2
-black --check .
+python -m black --check .
 
 echo "🔤 MyPy…"
 python -m pip install --quiet mypy==1.10.0


### PR DESCRIPTION
## Summary
- ensure lint tooling is present in `ci_sweep.sh`
- install ruff and black in one shot

## Testing
- `bash -n scripts/ci_sweep.sh`
- `./scripts/ci_sweep.sh` *(fails: Could not fetch package because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_686be4cf3a64832789133c40fff57bf2