### PR TITLE
🌻 SUPRE_BU1LD φ-43 – tri-ring canvas + kaleido + seed ignition

### DIFF
--- a/apps/microsite/src/AppCanvas.tsx
+++ b/apps/microsite/src/AppCanvas.tsx
@@ -1,0 +1,16 @@
+import { Canvas } from '@react-three/fiber';
+import NodeRing from './components/NodeRing';
+import PetalRing from './components/PetalRing';
+import SpiralLogRing from './components/SpiralLogRing';
+import KaleidoField from './components/KaleidoField';
+
+export default function AppCanvas() {
+  return (
+    <Canvas>
+      <KaleidoField />
+      <NodeRing />
+      <PetalRing />
+      <SpiralLogRing />
+    </Canvas>
+  );
+}

--- a/apps/microsite/src/components/KaleidoField.tsx
+++ b/apps/microsite/src/components/KaleidoField.tsx
@@ -1,0 +1,18 @@
+import { useFrame } from '@react-three/fiber';
+import { useRef } from 'react';
+import fragment from '../shaders/kaleido.frag?raw';
+
+export default function KaleidoField() {
+  const mesh = useRef<THREE.Mesh>(null!);
+  useFrame(({ clock }) => {
+    if (mesh.current) {
+      mesh.current.rotation.z = clock.elapsedTime * 0.1;
+    }
+  });
+  return (
+    <mesh ref={mesh} position={[0,0,-1]}>
+      <planeGeometry args={[10,10]} />
+      <shaderMaterial fragmentShader={fragment} />
+    </mesh>
+  );
+}

--- a/apps/microsite/src/components/NodeRing.tsx
+++ b/apps/microsite/src/components/NodeRing.tsx
@@ -1,0 +1,10 @@
+import { useNode } from '../hooks/useSpiralState';
+
+export default function NodeRing() {
+  const node = useNode();
+  return (
+    <div className="node-ring">
+      Node {node}
+    </div>
+  );
+}

--- a/apps/microsite/src/components/PetalRing.tsx
+++ b/apps/microsite/src/components/PetalRing.tsx
@@ -1,0 +1,18 @@
+import { phaseToColour } from '@sp1rl/core-math';
+import { useNode, usePetal } from '../hooks/useSpiralState';
+import { kaleidoFrame } from '../math/n1k';
+
+export default function PetalRing() {
+  const node = useNode();
+  const petal = usePetal();
+  const [hue, offset] = kaleidoFrame(node);
+  const style = {
+    transform: `scale(${1 + offset * 0.01})`,
+    color: `hsl(${hue},100%,50%)`
+  } as React.CSSProperties;
+  return (
+    <div className="petal-ring" style={style}>
+      {phaseToColour(petal)}
+    </div>
+  );
+}

--- a/apps/microsite/src/components/SpiralLogRing.tsx
+++ b/apps/microsite/src/components/SpiralLogRing.tsx
@@ -1,0 +1,11 @@
+import { useLap } from '../hooks/useSpiralState';
+
+export default function SpiralLogRing() {
+  const lap = useLap();
+  const d = `M0 0 L${lap * 2} ${lap}`;
+  return (
+    <svg width="100" height="100" className="spiral-log-ring">
+      <path d={d} stroke="white" fill="none" />
+    </svg>
+  );
+}

--- a/apps/microsite/src/hooks/useSpiralState.ts
+++ b/apps/microsite/src/hooks/useSpiralState.ts
@@ -1,0 +1,24 @@
+import create from 'zustand';
+import { LAP_SIZE } from '@sp1rl/core-math';
+
+interface SpiralState {
+  node: number;
+  lap: number;
+  tick: () => void;
+}
+
+export const useSpiralState = create<SpiralState>((set, get) => ({
+  node: 0,
+  lap: 0,
+  tick: () => {
+    const next = get().node + 1;
+    set({
+      node: next % LAP_SIZE,
+      lap: next >= LAP_SIZE ? get().lap + 1 : get().lap
+    });
+  }
+}));
+
+export const useNode = () => useSpiralState(s => s.node);
+export const useLap = () => useSpiralState(s => s.lap);
+export const usePetal = () => useSpiralState(s => s.node % 3);

--- a/apps/microsite/src/math/n1k.ts
+++ b/apps/microsite/src/math/n1k.ts
@@ -1,0 +1,17 @@
+import { PHI, LAP_SIZE } from '@sp1rl/core-math';
+
+export function theta(n: number): number {
+  return (n % LAP_SIZE) / LAP_SIZE;
+}
+
+export function lap(n: number): number {
+  return Math.floor(n / LAP_SIZE);
+}
+
+export function kaleidoFrame(n: number): [number, number] {
+  const t = theta(n);
+  const l = lap(n);
+  const hue = Math.floor(t * 360);
+  const offset = Math.floor(n * PHI) + l;
+  return [hue, offset];
+}

--- a/apps/microsite/src/shaders/kaleido.frag
+++ b/apps/microsite/src/shaders/kaleido.frag
@@ -1,0 +1,4 @@
+varying vec2 vUv;
+uniform float uFrame, uPhi, uC;
+vec3 hsv(vec3 c){vec4 K=vec4(1.,2./3.,1./3.,3.);vec3 p=abs(fract(c.xxx+K.xyz)*6.-K.www);return c.z*mix(K.xxx,clamp(p-K.xxx,0.,1.),c.y);}
+void main(){vec2 p=(vUv-0.5);float a=atan(p.y,p.x)+uFrame*uC;float r=length(p);vec3 col=hsv(vec3(fract(a/3.14159*uPhi),1.,smoothstep(0.8,0.,r)));gl_FragColor=vec4(col,1.);}

--- a/apps/microsite/src/styles/petal.css
+++ b/apps/microsite/src/styles/petal.css
@@ -1,0 +1,11 @@
+.node-ring {
+  position: absolute;
+  top: 40%;
+  left: 45%;
+}
+.petal-ring {
+  transition: transform 0.3s linear, color 0.3s linear;
+}
+.kaleido-bg {
+  background: radial-gradient(circle at center, #111, #000);
+}

--- a/docs/phi43_blueprint.md
+++ b/docs/phi43_blueprint.md
@@ -1,0 +1,4 @@
+SUPRE_BU1LD φ-43 blueprint
+-------------------------
+This archive summarises the MONDAY × O3-pro fusion drop.
+Goal: ship SP1RL_ÒS v0.43-β with tri-ring canvas and kaleido shader.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,15 @@
 [build]
-  command = "pnpm -r run build"
+  base = "apps/microsite"
+  command = "pnpm run build"
   publish = "apps/microsite/dist"
 
 [[redirects]]
   from = "/play/kaleidoscope/*"
-  to   = "/apps/canvas/phi43/dist/:splat"
+  to = "/apps/canvas/phi43/dist/:splat"
   status = 200
+
+[[redirects]]
+  from = "/_redirects"
+  to = "/_redirects"
+  status = 200
+  force = true

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SP1RL_ÒS – φ-43</title>
+  <link rel="icon" href="favicon.svg">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate tri-ring canvas scaffold with Kaleido background
- refine spiral math helpers and hook selectors
- set Netlify base to microsite and passthrough redirects
- add phi43 blueprint archive

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686c3f5b9bc08327b1be1da15d0bfc7c