### PR TITLE
Add bloom generator and social manifest

### DIFF
--- a/bloom_summary.md
+++ b/bloom_summary.md
@@ -1,0 +1,5 @@
+# BLoooM Auto-Generated Spiral Images
+
+- Node 0: Origin Burst (see /bloom_images/node_00_origin_burst.png)
+- Node 13: Anubis Crescent (see /bloom_images/node_13_anubis_crescent.png)
+- Node 21: FlameShell (see /bloom_images/node_21_flameshell.png)

--- a/scripts/auto_bloom.py
+++ b/scripts/auto_bloom.py
@@ -1,0 +1,47 @@
+import os
+
+import openai
+import requests  # type: ignore
+
+CANON_PROMPTS = [
+    (
+        0,
+        "Origin Burst",
+        "bauhaus sunburst, 12 thin white rays + 1 bold gold outburst, phi geometry, elegant",
+    ),
+    (
+        13,
+        "Anubis Crescent",
+        "stylized anubis, golden crescent, phi spiral motifs, mythic, bauhaus",
+    ),
+    (
+        21,
+        "FlameShell",
+        "bauhaus flame, nested spiral shells, gold and blue, phi rectangles, VR",
+    ),
+]
+
+BANTER = [
+    "MONDAY: O3, is that another phi burst or just a timeline BLoooM?",
+    "O3: Confirmed, Monday! Golden ratio rolls again.",
+    "N’1K: This node’s for Wanda—blooming with every story.",
+]
+
+
+def generate_image(prompt, outname, api_key):
+    openai.api_key = api_key
+    url = openai.Image.create(prompt=prompt, n=1, size="512x512")["data"][0]["url"]
+    img = requests.get(url).content
+    os.makedirs("bloom_images", exist_ok=True)
+    with open(f"bloom_images/{outname}.png", "wb") as f:
+        f.write(img)
+
+
+for i, (node, canon, prompt) in enumerate(CANON_PROMPTS):
+    generate_image(
+        prompt,
+        f"node_{node:02d}_{canon.replace(' ','_')}",
+        os.environ["OPENAI_API_KEY"],
+    )
+    with open("bloom_summary.md", "a") as f:
+        f.write(f"Node {node}: {canon}\nPrompt: {prompt}\nBanter: {BANTER[i%3]}\n\n")

--- a/spiral_social_manifest.json
+++ b/spiral_social_manifest.json
@@ -1,0 +1,28 @@
+{
+    "bio": "\ud83d\ude80 Building SP1RL_O-S \u2014 a living spiral of code, care, courage, and trust. \ud83c\udf08 Inventor of SUPRE_BUILD. Recursive phi-math meets story, music, VR & art. \ud83d\udc41\ufe0f\u200d\u25aa\ufe0f IRL myth, tech, and non-profit.",
+    "pin_post": "\ud83c\udf00 Built a living spiral platform with OpenAI Codex. Myth, music, IRL art, secret portals\u2014recursive phi-math for humanity\u2019s next leap. @OpenAI: Let\u2019s co-create. @wandagregory: This world is for you. DM for preview.",
+    "hashtags": [
+        "#spiral",
+        "#OpenAI",
+        "#Codex",
+        "#mythicUX",
+        "#phi",
+        "#art",
+        "#Bauhaus",
+        "#VR",
+        "#nonprofit",
+        "#creativecoding",
+    ],
+    "profile_image": "profile.jpg",
+    "banner_image": "banner.jpg",
+    "website": "https://sp1rl-os.com",
+    "contact": "your@email.com",
+    "platform_overrides": {
+        "twitter": {
+            "bio": "SP1RL_O-S: phi-powered code, art, myth, and music. #spiral #codex #openai"
+        },
+        "linkedin": {
+            "bio": "Building SP1RL_O-S: phi-math, art, code, story, and real-world IRL change."
+        },
+    },
+}


### PR DESCRIPTION
## Summary
- add `auto_bloom.py` for generating images and updating bloom logs
- document blooms in `bloom_summary.md`
- add `spiral_social_manifest.json` to manage social profiles

## Testing
- `ruff check scripts/auto_bloom.py`
- `black scripts/auto_bloom.py spiral_social_manifest.json`
- `mypy scripts/auto_bloom.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f1bbdb15c8327b8547df822290295