### PR TITLE
SP1RL Codex — Module Registry + Dynamic Loader + Captain Mints wiring

### DIFF
--- a/SP1RL_O-S-core/codex/_registry/manifest.json
+++ b/SP1RL_O-S-core/codex/_registry/manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://sp1rl.os/registry.schema.json",
+  "version": 1,
+  "modules": [
+    {
+      "id": "teal-math@stable",
+      "kind": "kernel",
+      "entry": "/SP1RL_O-S-core/codex/captain_mints/mod/teal_math.v1.js",
+      "deps": [],
+      "features": ["teal-lock", "deltas", "essence-score"]
+    },
+    {
+      "id": "plots@stable",
+      "kind": "widget",
+      "entry": "/SP1RL_O-S-core/codex/captain_mints/mod/plots.v1.js",
+      "deps": [],
+      "features": ["hinge-plot"]
+    }
+  ]
+}

--- a/SP1RL_O-S-core/codex/_runtime/importmap.json
+++ b/SP1RL_O-S-core/codex/_runtime/importmap.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "sp1rl:loader": "/SP1RL_O-S-core/codex/_runtime/module-loader.js"
+  }
+}

--- a/SP1RL_O-S-core/codex/_runtime/module-loader.js
+++ b/SP1RL_O-S-core/codex/_runtime/module-loader.js
@@ -1,0 +1,63 @@
+const REGISTRY_URL = '/SP1RL_O-S-core/codex/_registry/manifest.json';
+const IMPORT_MAP_URL = '/SP1RL_O-S-core/codex/_runtime/importmap.json';
+const cache = {};
+let map = {};
+
+export async function init() {
+  try {
+    const [manifest, base] = await Promise.all([
+      fetch(REGISTRY_URL).then(r => r.json()),
+      fetch(IMPORT_MAP_URL).then(r => r.json())
+    ]);
+    map = { ...(base.imports || {}) };
+    (manifest.modules || []).forEach(m => {
+      map[m.id] = m.entry;
+    });
+  } catch (_) {
+    try {
+      const base = await fetch(IMPORT_MAP_URL).then(r => r.json());
+      map = { ...(base.imports || {}) };
+    } catch (e) {
+      map = {};
+    }
+  }
+}
+
+export async function load(id) {
+  const entry = map[id];
+  if (!entry) {
+    return {};
+  }
+  if (cache[id]) {
+    return cache[id];
+  }
+  try {
+    const mod = await import(entry);
+    cache[id] = mod;
+    return mod;
+  } catch (e) {
+    return {};
+  }
+}
+
+export async function hotSwap(id, newEntry) {
+  map[id] = newEntry;
+  delete cache[id];
+  return load(id);
+}
+
+export function unload(id) {
+  delete cache[id];
+}
+
+export function require(ids) {
+  return {
+    async withFallbacks() {
+      const mods = {};
+      for (const id of ids) {
+        mods[id] = await load(id);
+      }
+      return mods;
+    }
+  };
+}

--- a/SP1RL_O-S-core/codex/captain_mints/README_MODS.md
+++ b/SP1RL_O-S-core/codex/captain_mints/README_MODS.md
@@ -1,0 +1,9 @@
+Captain Mints — Modular Extras
+------------------------------
+Modules are declared in codex/_registry/manifest.json.
+Each module provides a stable ESM entry; update 'entry' to swap implementation without touching the app.
+
+Add a new math kernel:
+ 1) drop file at codex/captain_mints/mod/teal_math.v2.js
+ 2) add a new record in manifest.json with id "teal-math@canary" and entry path
+ 3) users can prefer canary via in-app Prefs; otherwise stable loads by default

--- a/SP1RL_O-S-core/codex/captain_mints/app.js
+++ b/SP1RL_O-S-core/codex/captain_mints/app.js
@@ -1,5 +1,21 @@
 const key = 'cm_ledger';
-let ledger = JSON.parse(localStorage.getItem(key) || '{"m":0,"items":[],"treasury":[]}');
+let ledger = JSON.parse(localStorage.getItem(key) || '{}');
+ledger = Object.assign({m:0, items:[], treasury:[], streams:{d:[], d1:[], d2:[], d3:[]}}, ledger);
+const prefKey = 'cm_pref';
+
+const mathMod = MODS['teal-math@stable'] || {};
+const plotMod = MODS['plots@stable'] || {};
+
+const essenceScore = mathMod.essenceScore || ((k) => 0.73);
+const updateStreams = mathMod.updateStreams || (() => {});
+const tealLock = mathMod.tealLock || (() => false);
+const drawSpiral = plotMod.drawSpiral || (() => {});
+const drawHinges = plotMod.drawHinges || (() => {});
+
+const badge = document.getElementById('teal-lock');
+if (!mathMod.essenceScore) {
+  badge.textContent = Math.random().toString(36).slice(2, 8);
+}
 
 function save() {
   localStorage.setItem(key, JSON.stringify(ledger));
@@ -19,16 +35,30 @@ function update() {
 
 function fire() {
   ledger.m += 1;
-  const item = {m: ledger.m, kappa: 0.000437, score: 0.73};
+  const kappa = 0.000437;
+  const score = essenceScore(kappa, ledger.streams);
+  updateStreams(ledger.streams, score);
+  const item = {m: ledger.m, kappa, score};
+  item.treasury = score >= 0.72;
   ledger.items.push(item);
-  if (item.score >= 0.72) {
+  if (item.treasury) {
     ledger.treasury.push(item);
   }
   save();
   update();
+  drawSpiral(document.getElementById('spiral'), ledger.items);
+  drawHinges(document.getElementById('chart'), ledger.streams);
+  const locked = tealLock(ledger.streams);
+  if (mathMod.essenceScore) {
+    badge.textContent = locked ? 'locked' : '';
+  }
+  if (ledger.m === 8) {
+    const hasCanary = MODS['teal-math@canary'] || MODS['plots@canary'];
+    localStorage.setItem(prefKey, JSON.stringify({prefer: hasCanary ? '@canary' : '@stable'}));
+  }
 }
 
 document.getElementById('fire').addEventListener('click', fire);
-
-document.getElementById('teal-lock').textContent = Math.random().toString(36).slice(2, 8);
 update();
+drawSpiral(document.getElementById('spiral'), ledger.items);
+drawHinges(document.getElementById('chart'), ledger.streams);

--- a/SP1RL_O-S-core/codex/captain_mints/index.html
+++ b/SP1RL_O-S-core/codex/captain_mints/index.html
@@ -16,6 +16,12 @@
   <canvas id="spiral"></canvas>
   <canvas id="chart"></canvas>
   <ul id="treasury"></ul>
+  <script type="importmap" src="/SP1RL_O-S-core/codex/_runtime/importmap.json"></script>
+  <script type="module">
+    window.SP1RL = await import('sp1rl:loader');
+    await SP1RL.init();
+    window.MODS = await SP1RL.require(['teal-math@stable','plots@stable']).withFallbacks();
+  </script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/SP1RL_O-S-core/codex/captain_mints/mod/plots.v1.js
+++ b/SP1RL_O-S-core/codex/captain_mints/mod/plots.v1.js
@@ -1,0 +1,50 @@
+function setup(canvas) {
+  const ctx = canvas.getContext('2d');
+  canvas.width = canvas.clientWidth || 200;
+  canvas.height = canvas.clientHeight || 200;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  return ctx;
+}
+
+export function drawSpiral(canvas, items) {
+  const ctx = setup(canvas);
+  const phi = Math.PI * (3 - Math.sqrt(5));
+  items.forEach((item, i) => {
+    const r = 4 * Math.sqrt(i + 1);
+    const a = (i + 1) * phi;
+    const x = canvas.width / 2 + r * Math.cos(a);
+    const y = canvas.height / 2 + r * Math.sin(a);
+    ctx.beginPath();
+    ctx.fillStyle = item.score >= 0.72 ? 'teal' : '#888';
+    ctx.arc(x, y, 3, 0, 2 * Math.PI);
+    ctx.fill();
+    if (item.witness) {
+      ctx.strokeStyle = 'red';
+      ctx.stroke();
+    }
+    if (item.treasury) {
+      ctx.strokeStyle = 'gold';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+  });
+}
+
+export function drawHinges(canvas, streams) {
+  const ctx = setup(canvas);
+  const names = ['d', 'd1', 'd2', 'd3'];
+  ctx.fillStyle = 'rgba(0,128,128,0.1)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  names.forEach((n, idx) => {
+    const arr = streams[n] || [];
+    if (!arr.length) return;
+    ctx.beginPath();
+    arr.forEach((v, j) => {
+      const x = (j / Math.max(arr.length - 1, 1)) * canvas.width;
+      const y = idx * 50 + 25 - v * 40;
+      if (j === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = 'teal';
+    ctx.stroke();
+  });
+}

--- a/SP1RL_O-S-core/codex/captain_mints/mod/teal_math.v1.js
+++ b/SP1RL_O-S-core/codex/captain_mints/mod/teal_math.v1.js
@@ -1,0 +1,41 @@
+function median(arr) {
+  if (!arr.length) return 0;
+  const s = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s[mid];
+}
+
+function mad(arr) {
+  if (!arr.length) return 1e-9;
+  const m = median(arr);
+  const dev = arr.map(v => Math.abs(v - m));
+  return median(dev) || 1e-9;
+}
+
+export function essenceScore(kappa, streams) {
+  const base = Math.exp(-Math.abs(kappa - 0.000437) * 1000);
+  const bonus = tealLock(streams) ? 0.1 : 0;
+  return Math.min(1, base + bonus);
+}
+
+export function updateStreams(streams, score) {
+  streams.d = streams.d || [];
+  streams.d1 = streams.d1 || [];
+  streams.d2 = streams.d2 || [];
+  streams.d3 = streams.d3 || [];
+  streams.d.push(score);
+  const n = streams.d.length;
+  streams.d1.push(n > 1 ? score - streams.d[n - 2] : 0);
+  streams.d2.push(n > 1 ? streams.d1[n - 1] - streams.d1[n - 2] : 0);
+  streams.d3.push(n > 1 ? streams.d2[n - 1] - streams.d2[n - 2] : 0);
+}
+
+export function tealLock(streams) {
+  const z = (arr) => {
+    const m = median(arr);
+    return arr.length ? Math.abs(arr[arr.length - 1] - m) / mad(arr) : 0;
+  };
+  const z2 = z(streams.d2 || []);
+  const z3 = z(streams.d3 || []);
+  return z2 > 2 && z3 > 2;
+}


### PR DESCRIPTION
## Summary
- add portable module registry with import map and dynamic loader
- implement TEAL math kernel and plot widget as swappable modules
- wire Captain Mints to fetch registry and load modules on demand

## Testing
- `pre-commit run --files SP1RL_O-S-core/codex/_registry/manifest.json SP1RL_O-S-core/codex/_runtime/importmap.json SP1RL_O-S-core/codex/_runtime/module-loader.js SP1RL_O-S-core/codex/captain_mints/mod/teal_math.v1.js SP1RL_O-S-core/codex/captain_mints/mod/plots.v1.js SP1RL_O-S-core/codex/captain_mints/index.html SP1RL_O-S-core/codex/captain_mints/app.js SP1RL_O-S-core/codex/captain_mints/README_MODS.md` *(fails: pre-commit not installed; attempted pip install but unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a25218de4883279e902c5e2d721f6a