### PR TITLE
feat: scaffold VR idea mapper front-end

### DIFF
--- a/webapp_vr/README.md
+++ b/webapp_vr/README.md
@@ -1,0 +1,17 @@
+# SP1RL Idea-Mapper (VR)
+
+## Run locally
+
+```bash
+cd webapp_vr
+npm ci
+npm run dev
+```
+
+## Overview
+- Visualizes ideas along a spiral in VR or 2D.
+- Scores Care, Courage, Trust (ZCM) and computes a TEAL hinge.
+- Layout jostle uses Δθ = 0.000437 rad per "fire!".
+- Spiral addresses encode idea state reversibly.
+
+Deploys on Netlify using the included `netlify.toml`.

--- a/webapp_vr/index.html
+++ b/webapp_vr/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SP1RL Idea-Mapper (VR)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webapp_vr/netlify.toml
+++ b/webapp_vr/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  base    = "webapp_vr"
+  publish = "webapp_vr/dist"
+  command = "npm ci && npm run build"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/webapp_vr/package.json
+++ b/webapp_vr/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sp1rl-idea-mapper",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18",
+    "@react-three/fiber": "^9",
+    "@react-three/drei": "^9",
+    "three": "^0.161",
+    "localforage": "^1.10.0",
+    "zustand": "^4",
+    "@tensorflow/tfjs": "^4",
+    "@tensorflow-models/universal-sentence-encoder": "^1",
+    "d3-force-3d": "^3",
+    "tinycolor2": "^1"
+  },
+  "devDependencies": {
+    "vite": "^5",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  },
+  "engines": { "node": ">=18 <21" }
+}

--- a/webapp_vr/src/App.tsx
+++ b/webapp_vr/src/App.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react';
+import Home from './routes/Home';
+import VRPortal from './routes/VRPortal';
+
+export default function App() {
+  const [route, setRoute] = useState<'home' | 'vr'>('home');
+  return route === 'home' ? (
+    <Home enterPortal={() => setRoute('vr')} />
+  ) : (
+    <VRPortal goHome={() => setRoute('home')} />
+  );
+}

--- a/webapp_vr/src/components/Exporter.tsx
+++ b/webapp_vr/src/components/Exporter.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { exportJSON, importJSON } from '../engine/IdeaStore';
+
+export default function Exporter(){
+  const handleExport = async ()=>{
+    const json = await exportJSON();
+    const blob = new Blob([json], { type:'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'ideas.json'; a.click();
+  };
+  const handleImport = async (e:React.ChangeEvent<HTMLInputElement>)=>{
+    const file = e.target.files?.[0];
+    if(file){
+      const text = await file.text();
+      await importJSON(text);
+    }
+  };
+  return (
+    <div>
+      <button onClick={handleExport}>Export JSON</button>
+      <input type="file" accept="application/json" onChange={handleImport} />
+    </div>
+  );
+}

--- a/webapp_vr/src/components/HUD.tsx
+++ b/webapp_vr/src/components/HUD.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { DTH } from '../engine/SpiralAddress';
+
+type Props = { onFire: () => void; step: number };
+
+export default function HUD({ onFire, step }: Props){
+  return (
+    <div className="hud">
+      <button onClick={onFire}>fire !</button>
+      <span> step: {step} &times; {DTH.toFixed(6)} rad</span>
+    </div>
+  );
+}

--- a/webapp_vr/src/components/IdeaForm.tsx
+++ b/webapp_vr/src/components/IdeaForm.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+
+type Props = { onSubmit:(text:string)=>void };
+
+export default function IdeaForm({ onSubmit }:Props){
+  const [text, setText] = useState('');
+  return (
+    <form onSubmit={e=>{e.preventDefault(); onSubmit(text);}}>
+      <textarea value={text} onChange={e=>setText(e.target.value)} placeholder="Intentional seed" />
+      <button type="submit">Add</button>
+    </form>
+  );
+}

--- a/webapp_vr/src/components/Inspector.tsx
+++ b/webapp_vr/src/components/Inspector.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Inspector(){
+  return <div>Inspector</div>;
+}

--- a/webapp_vr/src/components/Timeline.tsx
+++ b/webapp_vr/src/components/Timeline.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Timeline(){
+  return <div>Timeline</div>;
+}

--- a/webapp_vr/src/engine/AddressCodec.ts
+++ b/webapp_vr/src/engine/AddressCodec.ts
@@ -1,0 +1,9 @@
+import { Params, encode, decode } from './SpiralAddress';
+
+export interface IdeaMeta {
+  params: Params;
+  text: string;
+}
+
+export const toAddress = (meta:IdeaMeta)=> encode(meta.params);
+export const fromAddress = (addr:string, text:string):IdeaMeta => ({ params: decode(addr), text });

--- a/webapp_vr/src/engine/Antonyms.ts
+++ b/webapp_vr/src/engine/Antonyms.ts
@@ -1,0 +1,5 @@
+export default [
+  ["fluidity","rigidity"],
+  ["playful","solemn"],
+  ["open","closed"]
+];

--- a/webapp_vr/src/engine/Embeddings.ts
+++ b/webapp_vr/src/engine/Embeddings.ts
@@ -1,0 +1,27 @@
+let model: any;
+
+async function loadModel(){
+  if(!model){
+    const use = await import('@tensorflow-models/universal-sentence-encoder');
+    model = await use.load();
+  }
+  return model;
+}
+
+export async function embed(text:string):Promise<number[]>{
+  const m = await loadModel();
+  const v = await m.embed(text);
+  const data = await v.data();
+  v.dispose();
+  return Array.from(data);
+}
+
+export function cosine(a:number[], b:number[]){
+  let dot=0,na=0,nb=0;
+  for(let i=0;i<a.length && i<b.length;i++){
+    dot += a[i]*b[i];
+    na += a[i]*a[i];
+    nb += b[i]*b[i];
+  }
+  return dot / Math.sqrt(na*nb);
+}

--- a/webapp_vr/src/engine/IdeaStore.ts
+++ b/webapp_vr/src/engine/IdeaStore.ts
@@ -1,0 +1,29 @@
+import localforage from 'localforage';
+import { Params } from './SpiralAddress';
+
+export interface Idea extends Params {
+  id: string;
+  text: string;
+}
+
+const store = localforage.createInstance({ name: 'ideas' });
+
+export async function saveIdea(idea:Idea){
+  await store.setItem(idea.id, idea);
+}
+
+export async function loadIdeas():Promise<Idea[]>{
+  const ideas:Idea[] = [];
+  await store.iterate((v:Idea)=>{ ideas.push(v); });
+  return ideas;
+}
+
+export async function exportJSON(){
+  const ideas = await loadIdeas();
+  return JSON.stringify(ideas);
+}
+
+export async function importJSON(json:string){
+  const ideas:Idea[] = JSON.parse(json);
+  for(const idea of ideas){ await saveIdea(idea); }
+}

--- a/webapp_vr/src/engine/PhiJostle.ts
+++ b/webapp_vr/src/engine/PhiJostle.ts
@@ -1,0 +1,20 @@
+import { DTH } from './SpiralAddress';
+
+export interface Node {
+  id: string;
+  radius: number;
+  theta: number;
+  x?: number; y?: number; z?: number;
+}
+
+export function step(nodes:Node[], _edges:any[], fireTick:number){
+  const angle = fireTick * DTH;
+  nodes.forEach(n=>{
+    n.theta += DTH;
+    const t = n.theta + angle;
+    n.x = n.radius * Math.cos(t);
+    n.y = n.radius * Math.sin(t);
+    n.z = 0;
+  });
+  return nodes;
+}

--- a/webapp_vr/src/engine/SpiralAddress.ts
+++ b/webapp_vr/src/engine/SpiralAddress.ts
@@ -1,0 +1,31 @@
+export type Params = {
+  kappa:number; phiTilt:number;
+  care:number; courage:number; trust:number;
+  primeIndex:number; epoch:number; seedHash:number;
+  microStep:number; // counts 0.000437-rad steps
+};
+
+const GOLDEN = (1+Math.sqrt(5))/2;
+const DTH = 0.000437;
+
+export function encode(p:Params):string {
+  // pack as JSON -> Uint8Array -> base64url with checksum
+  const payload = JSON.stringify(p);
+  const bytes   = new TextEncoder().encode(payload);
+  let sum = 0; for (const b of bytes) sum = (sum + b) % 9973;
+  const tag = (p.primeIndex*31 + p.epoch*7 + sum) % 104729;
+  return btoa(String.fromCharCode(...bytes)) + "." + tag.toString(36);
+}
+
+export function decode(addr:string):Params {
+  const [b64, tag] = addr.split(".");
+  const bytes = Uint8Array.from(atob(b64), c=>c.charCodeAt(0));
+  const payload = JSON.parse(new TextDecoder().decode(bytes));
+  // simple checksum verify (same as encode)
+  let sum = 0; for (const b of bytes) sum = (sum + b) % 9973;
+  const check = (payload.primeIndex*31 + payload.epoch*7 + sum) % 104729;
+  if (check.toString(36) !== tag) throw new Error("Address checksum fail");
+  return payload;
+}
+
+export { GOLDEN, DTH };

--- a/webapp_vr/src/engine/TEAL.ts
+++ b/webapp_vr/src/engine/TEAL.ts
@@ -1,0 +1,16 @@
+export const TEAL_LOCK = 0.72;
+
+export function tealScore(care:number, courage:number, trust:number):number{
+  const d = Math.abs(care - courage);
+  return 1 - d*(1-trust); // convex hinge
+}
+
+export const isTeal = (t:number)=> t>=TEAL_LOCK;
+
+export function tealColor(t:number){
+  return `rgba(0,128,128,${t})`;
+}
+
+export function hingeLine(){
+  return { start:[-1,0,0], end:[1,0,0], color:tealColor(1) };
+}

--- a/webapp_vr/src/engine/ZCM.ts
+++ b/webapp_vr/src/engine/ZCM.ts
@@ -1,0 +1,21 @@
+export type Pair = { a:number; b:number };
+export type ZCMScore = { care:number; courage:number; trust:number; dominance:'care'|'courage'|'trust' };
+
+const clamp = (v:number)=> Math.max(0, Math.min(1, v));
+const avg = (arr:number[]) => arr.length? arr.reduce((a,b)=>a+b,0)/arr.length : 0.5;
+
+export function scoreFromPairs(pairs:Pair[]):ZCMScore{
+  const care = clamp(avg(pairs.map(p=>p.a)));
+  const courage = clamp(avg(pairs.map(p=>p.b)));
+  const trust = clamp(1 - Math.abs(care-courage));
+  const dominance = care>=courage && care>=trust ? 'care' : courage>=trust ? 'courage' : 'trust';
+  return { care, courage, trust, dominance };
+}
+
+export function scoreFromTextEmbedding(vec:number[]):ZCMScore{
+  const care = clamp(Math.abs(vec[0]??0)%1);
+  const courage = clamp(Math.abs(vec[1]??0)%1);
+  const trust = clamp(Math.abs(vec[2]??0)%1);
+  const dominance = care>=courage && care>=trust ? 'care' : courage>=trust ? 'courage' : 'trust';
+  return { care, courage, trust, dominance };
+}

--- a/webapp_vr/src/main.tsx
+++ b/webapp_vr/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/webapp_vr/src/routes/Home.tsx
+++ b/webapp_vr/src/routes/Home.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+type Props = { enterPortal: () => void };
+
+export default function Home({ enterPortal }: Props) {
+  return (
+    <div>
+      <h1>SP1RL Idea-Mapper (VR)</h1>
+      <button onClick={enterPortal}>Enter Portal</button>
+      <button>New Seed</button>
+      <button>Import/Export</button>
+      <button>Golden Treasury</button>
+      <footer>
+        &Delta;&theta; = 0.000437 rad | &phi;-jostle on fire ! | TEAL &ge; 0.72 locks
+      </footer>
+    </div>
+  );
+}

--- a/webapp_vr/src/routes/VRPortal.tsx
+++ b/webapp_vr/src/routes/VRPortal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import ThreeConeScene from '../scenes/ThreeConeScene';
+
+interface Props { goHome: () => void; }
+
+export default function VRPortal({ goHome }: Props) {
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <button style={{ position: 'absolute', top: 10, left: 10, zIndex: 1 }} onClick={goHome}>
+        Home
+      </button>
+      <Canvas>
+        <ambientLight />
+        <ThreeConeScene />
+      </Canvas>
+    </div>
+  );
+}

--- a/webapp_vr/src/scenes/AmesWindowScene.tsx
+++ b/webapp_vr/src/scenes/AmesWindowScene.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AmesWindowScene(){
+  return null; // Ames window illusion placeholder
+}

--- a/webapp_vr/src/scenes/KaleidoScene.tsx
+++ b/webapp_vr/src/scenes/KaleidoScene.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function KaleidoScene(){
+  return null; // shader-driven kaleidoscope placeholder
+}

--- a/webapp_vr/src/scenes/ThreeConeScene.tsx
+++ b/webapp_vr/src/scenes/ThreeConeScene.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function ThreeConeScene(){
+  return (
+    <>
+      <mesh rotation={[-Math.PI/2,0,0]} position={[0,0,0]}>
+        <coneGeometry args={[1,2,32]} />
+        <meshStandardMaterial color="blue" wireframe />
+      </mesh>
+      <mesh rotation={[-Math.PI/2,0,0]} position={[2,0,0]}>
+        <coneGeometry args={[1,2,32]} />
+        <meshStandardMaterial color="yellowgreen" wireframe />
+      </mesh>
+      <mesh rotation={[-Math.PI/2,0,0]} position={[-2,0,0]}>
+        <coneGeometry args={[1,2,32]} />
+        <meshStandardMaterial color="orangered" wireframe />
+      </mesh>
+      <mesh rotation={[-Math.PI/2,0,0]}>
+        <ringGeometry args={[1.1,1.2,32]} />
+        <meshBasicMaterial color="teal" />
+      </mesh>
+    </>
+  );
+}

--- a/webapp_vr/src/shaders/kaleido.glsl
+++ b/webapp_vr/src/shaders/kaleido.glsl
@@ -1,0 +1,3 @@
+void main(){
+  gl_FragColor = vec4(0.0,0.5,0.5,1.0);
+}

--- a/webapp_vr/src/shaders/phyllotaxis.glsl
+++ b/webapp_vr/src/shaders/phyllotaxis.glsl
@@ -1,0 +1,3 @@
+void main(){
+  gl_FragColor = vec4(1.0);
+}

--- a/webapp_vr/tsconfig.json
+++ b/webapp_vr/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/webapp_vr/tsconfig.node.json
+++ b/webapp_vr/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"]
+  }
+}

--- a/webapp_vr/vite.config.ts
+++ b/webapp_vr/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add `webapp_vr` Vite + React TypeScript scaffold for SP1RL Idea‑Mapper
- implement core math modules for spiral address, TEAL hinge, ZCM scoring and layout jostle
- include Netlify config and placeholder scenes/components for VR visualization

## Testing
- `npm run build` *(fails: vite: not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3162fba4c8327ae338006d6a0bc74