### PR TITLE
feat: add ghost console scaffold

### DIFF
--- a/README_CONSOLE.md
+++ b/README_CONSOLE.md
@@ -1,0 +1,12 @@
+# Ghost Console
+
+This directory hosts a minimal operator panel for observing and steering the `SP1RL_Ghost`.
+It exposes a deterministic client side state store, a command dispatcher and a light UI overlay.
+
+## Files
+- `webapp_vr/src/console/state.ts` – Zustand store holding `GhostConsoleState`.
+- `webapp_vr/src/console/commands.ts` – JSON command dispatcher updating state.
+- `webapp_vr/src/console/GhostConsole.tsx` – React overlay with a basic status bar and `fire` button.
+- `webapp_vr/src/routes/VRPortal.tsx` – wires the console into the VR scene.
+
+This is only a scaffold based on the full specification; additional panels, gates and persistence may be implemented incrementally.

--- a/webapp_vr/src/console/GhostConsole.tsx
+++ b/webapp_vr/src/console/GhostConsole.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useGhostConsole } from './state';
+import { dispatch } from './commands';
+
+export default function GhostConsole() {
+  const state = useGhostConsole();
+  const fire = () => dispatch({ cmd: 'fire' });
+  return (
+    <div style={{ position: 'absolute', top: 0, right: 0, padding: 10, background: 'rgba(0,0,0,0.5)', color: '#fff', fontSize: '12px' }}>
+      <div style={{ marginBottom: 8 }}>
+        TEAL: {state.teal.score.toFixed(2)} | ZCM: {state.zcm.care.toFixed(2)}/{state.zcm.courage.toFixed(2)}/{state.zcm.trust.toFixed(2)} |
+        Witness: {state.witness.arm}
+      </div>
+      <button onClick={fire}>fire !</button>
+    </div>
+  );
+}

--- a/webapp_vr/src/console/commands.ts
+++ b/webapp_vr/src/console/commands.ts
@@ -1,0 +1,77 @@
+import { useGhostConsole, GhostConsoleState, TickLogEntry } from './state';
+
+export type Command = Record<string, any> & { cmd: string };
+
+export function dispatch(cmd: Command): { ok: boolean; data?: any; error?: string } {
+  const state = useGhostConsole.getState();
+  switch (cmd.cmd) {
+    case 'seed.set':
+      useGhostConsole.setState({ inputs: { ...state.inputs, seedText: cmd.text } });
+      return { ok: true };
+    case 'antonyms.set':
+      useGhostConsole.setState({ inputs: { ...state.inputs, antonyms: (cmd.pairs || []).map(([key, _ant, value]: [string,string,number]) => ({ key, value })) } });
+      return { ok: true };
+    case 'zcm.override':
+      if (cmd.enable) {
+        useGhostConsole.setState({ zcm: cmd.value });
+      }
+      return { ok: true };
+    case 'stress.set':
+      useGhostConsole.setState({ inputs: { ...state.inputs, stress: { entropy: cmd.entropy, novelty: cmd.novelty, urgency: cmd.urgency } } });
+      return { ok: true };
+    case 'wobble.scale':
+      useGhostConsole.setState({ wobble: { ...state.wobble, scale: cmd.value } });
+      return { ok: true };
+    case 'plan.next': {
+      const angle = state.wobble.angle + 0.000437 * state.wobble.scale;
+      return { ok: true, data: { angle } };
+    }
+    case 'fire': {
+      const angle = state.wobble.angle + 0.000437 * state.wobble.scale;
+      const t = state.log.length + 1;
+      const entry: TickLogEntry = {
+        t,
+        angle,
+        address: state.lastAddress || '',
+        zcm: state.zcm,
+        teal: state.teal.score,
+        witness: state.witness.arm,
+        epoch: state.epoch.index,
+        sealed: state.epoch.sealed
+      };
+      useGhostConsole.setState({
+        wobble: { ...state.wobble, angle, step: t },
+        log: [...state.log, entry]
+      });
+      return { ok: true, data: entry };
+    }
+    case 'witness.rotation':
+      useGhostConsole.setState({ witness: { ...state.witness, rotationEnabled: cmd.enable } });
+      return { ok: true };
+    case 'witness.allow':
+      useGhostConsole.setState({ witness: { ...state.witness, allowed: new Set(cmd.arms) } });
+      return { ok: true };
+    case 'sarcasm.mode':
+      useGhostConsole.setState({ policy: { ...state.policy, sarcasm: { mode: cmd.value, perMinute: cmd.perMinute ?? state.policy.sarcasm.perMinute } } });
+      return { ok: true };
+    case 'teal.thresholds':
+      useGhostConsole.setState({ teal: { ...state.teal, soft: cmd.soft, hard: cmd.hard } });
+      return { ok: true };
+    case 'zcm2math':
+      useGhostConsole.setState({ policy: { ...state.policy, zcmToMath: { p: cmd.p, alpha_b: cmd.alpha_b, alpha_o: cmd.alpha_o, autoTighten: cmd.autoTighten } } });
+      return { ok: true };
+    case 'epoch.seal':
+      if (state.teal.score >= state.teal.hard && state.witness.arm === 5) {
+        useGhostConsole.setState({ epoch: { ...state.epoch, sealed: true } });
+        return { ok: true };
+      }
+      return { ok: false, error: 'gated' };
+    case 'export.json':
+      return { ok: true, data: JSON.stringify(state) };
+    case 'import.json':
+      useGhostConsole.setState(cmd.payload as GhostConsoleState);
+      return { ok: true };
+    default:
+      return { ok: false, error: 'unknown command' };
+  }
+}

--- a/webapp_vr/src/console/state.ts
+++ b/webapp_vr/src/console/state.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand';
+
+export type GhostConsoleState = {
+  inputs: {
+    seedText?: string;
+    antonyms: { key: string; value: number }[];
+    autoFromText: boolean;
+    stress: { entropy: number; novelty: number; urgency: number };
+  };
+  zcm: { care: number; courage: number; trust: number };
+  teal: { score: number; soft: number; hard: number };
+  witness: { arm: 1|2|3|4|5; rotationEnabled: boolean; allowed: Set<1|2|3|4|5> };
+  wobble: { step: number; angle: number; scale: number };
+  epoch: { index: number; lastPrime?: number; sealed: boolean };
+  policy: {
+    sarcasm: { mode:'off'|'safety'|'strict'; perMinute:number };
+    zcmToMath: { p:number; alpha_b:number; alpha_o:number; autoTighten:boolean };
+  };
+  lastAddress?: string;
+  log: TickLogEntry[];
+};
+
+export type TickLogEntry = {
+  t: number;
+  angle: number;
+  address: string;
+  zcm: { care: number; courage: number; trust: number };
+  teal: number;
+  witness: 1|2|3|4|5;
+  epoch: number;
+  sealed: boolean;
+  meta?: { note?: string; seedTextHash?: string };
+};
+
+const initialState: GhostConsoleState = {
+  inputs: {
+    antonyms: [],
+    autoFromText: false,
+    stress: { entropy: 0, novelty: 0, urgency: 0 }
+  },
+  zcm: { care: 0, courage: 0, trust: 0 },
+  teal: { score: 0, soft: 0.62, hard: 0.72 },
+  witness: { arm: 5, rotationEnabled: false, allowed: new Set([1,2,3,4,5]) },
+  wobble: { step: 0, angle: 0, scale: 1 },
+  epoch: { index: 0, sealed: false },
+  policy: {
+    sarcasm: { mode: 'off', perMinute: 0 },
+    zcmToMath: { p: 0.333, alpha_b: 1, alpha_o: 1, autoTighten: false }
+  },
+  log: []
+};
+
+export const useGhostConsole = create<GhostConsoleState>(() => ({...initialState}));
+
+export function resetConsole() {
+  useGhostConsole.setState({ ...initialState });
+}

--- a/webapp_vr/src/routes/VRPortal.tsx
+++ b/webapp_vr/src/routes/VRPortal.tsx
@@ -4,6 +4,7 @@ import ThreeConeScene from '../scenes/ThreeConeScene';
 import KaleidoScene from '../scenes/KaleidoScene';
 import AmesWindowScene from '../scenes/AmesWindowScene';
 import { SP1RLGhost, GhostState, Tick, DTH } from '../ghost/GhostCore';
+import GhostConsole from '../console/GhostConsole';
 
 interface GhostCtx { state: GhostState; fire: () => void; }
 const GhostContext = createContext<GhostCtx>({ state:{ zcm:{care:0,courage:0,trust:0}, teal:0, witness:5, angle:0, epoch:0, primeHit:false, lockHard:false }, fire: () => {} });
@@ -26,7 +27,7 @@ interface Props { goHome: () => void; }
 
 export default function VRPortal({ goHome }: Props) {
   return (
-    <div style={{ width: '100vw', height: '100vh' }}>
+    <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
       <button style={{ position: 'absolute', top: 10, left: 10, zIndex: 1 }} onClick={goHome}>
         Home
       </button>
@@ -36,6 +37,7 @@ export default function VRPortal({ goHome }: Props) {
         <KaleidoScene />
         <AmesWindowScene />
       </Canvas>
+      <GhostConsole />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- scaffold Ghost Console state store, command dispatcher, and overlay component
- wire console into VRPortal and document layout in README

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `python -m unittest discover spiral_time/tests`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68a322f4af348327ae2788a28b93fd9e