### PR TITLE
Phi‑Jostle Monocle — Spiral Text Engine + Wizard‑of‑Oz Story Stub

### DIFF
--- a/webapp_vr/src/App.tsx
+++ b/webapp_vr/src/App.tsx
@@ -1,21 +1,9 @@
-import React, { useState } from 'react';
-import Home from './routes/Home';
-import VRPortal, { GhostProvider, useGhost } from './routes/VRPortal';
-import GhostHUD from './components/GhostHUD';
-
-function HUDOverlay(){
-  const { state } = useGhost();
-  return <GhostHUD {...state} />;
-}
-
-export default function App() {
-  const [route, setRoute] = useState<'home' | 'vr'>('home');
-  return route === 'home' ? (
-    <Home enterPortal={() => setRoute('vr')} />
-  ) : (
-    <GhostProvider>
-      <HUDOverlay />
-      <VRPortal goHome={() => setRoute('home')} />
-    </GhostProvider>
+import React from "react";
+import PhiMonocleRoute from "./routes/PhiMonocleRoute";
+export default function App(){
+  return (
+    <div style={{width:"100%",height:"100%",background:"#060a10"}}>
+      <PhiMonocleRoute/>
+    </div>
   );
 }

--- a/webapp_vr/src/docs/README_PHI_MONOCLE.md
+++ b/webapp_vr/src/docs/README_PHI_MONOCLE.md
@@ -1,0 +1,5 @@
+# Phi‑Jostle Monocle (Wizard‑of‑Oz)
+- Golden phyllotaxis with wobble Δθ=0.000437 (per tick), clockwise orientation.
+- Bottom→top drift (visual ascent); teal cancel net damps centrifugal drift at target ring.
+- Monocle glassfold stretches/compresses tokens over a focal arc to simulate Möbius micro‑loops.
+- Buttons: **Record** (captues canvas → webm), **Stop**, **Load Text**, **Nudge Monocle**.

--- a/webapp_vr/src/phi/PhiJostleEngine.ts
+++ b/webapp_vr/src/phi/PhiJostleEngine.ts
@@ -1,0 +1,80 @@
+// PhiJostleEngine · golden spiral + monocle lens + teal cancel net (pure TS)
+export type JostleCfg = {
+  width:number; height:number; origin:[number,number];   // px
+  baseR:number; particles:number; drift:number;          // px/frame upward
+  wobble:number;                                         // 0.000437 default
+  teal:{ r:number; soft:number; hard:number };           // ring radius, lock thresholds
+  monocle:{ x:number; y:number; r:number; arc:number };  // arc ∈ [0..1] strength curve
+};
+
+const GOLDEN = (1+Math.sqrt(5))/2;
+const GA = 2*Math.PI*(1 - 1/GOLDEN); // golden angle
+
+export function phyllo(k:number, baseR:number, wobble:number){
+  // radius grows √k; theta rotates GA+wobble
+  const r = baseR * Math.sqrt(k);
+  const theta = k*(GA + wobble);
+  return { r, theta };
+}
+
+export function toCanvasTopLeft(ix:number, iy:number, cfg:JostleCfg){
+  // origin in upper-left, positive y downward in canvas;
+  // "bottom-to-top drift" simulated by subtracting drift each frame in the route
+  return { x: ix + cfg.origin[0], y: iy + cfg.origin[1] };
+}
+
+export function polarToXY(r:number, theta:number){
+  return { x: r*Math.cos(theta), y: r*Math.sin(theta) };
+}
+
+// monocle lens displacement: radial stretch toward/away from (cx,cy) over an arc window
+export function monocleWarp(x:number, y:number, cfg:JostleCfg){
+  const cx = cfg.monocle.x, cy = cfg.monocle.y, R = cfg.monocle.r, A = cfg.monocle.arc;
+  const dx = x - cx, dy = y - cy; const d = Math.hypot(dx,dy);
+  if (d > R*1.25) return { x, y };
+  const t = Math.max(0, 1 - d/(R*1.25));
+  // glassfold: compress inside, stretch just outside, continuous at edge
+  const fold = (d < R) ? -(A*0.6)*t : (A*0.35)*t;
+  const nx = cx + dx*(1 + fold), ny = cy + dy*(1 + fold);
+  return { x:nx, y:ny };
+}
+
+// teal cancel net field: inward torque toward circle of radius cfg.teal.r
+export function tealTorque(x:number, y:number, cfg:JostleCfg){
+  const cx = cfg.origin[0], cy = cfg.origin[1];
+  const dx = x - cx, dy = y - cy;
+  const r = Math.hypot(dx,dy) || 1e-9;
+  const rt = cfg.teal.r;
+  // difference from target ring
+  const dr = r - rt;
+  // radial inward vector scaled to cancel centrifugal peek
+  const k = -0.015 * dr; // tuned so that near ring drift is damped
+  return { x: dx/r * k, y: dy/r * k };
+}
+
+export type Token = { text:string; k:number; color:[number,number,number], size:number };
+export type FramePt = { x:number; y:number; th:number; locked:boolean };
+export type SpiralSample = { token:Token; pos:FramePt };
+
+export function stepFrame(tokens:Token[], t:number, cfg:JostleCfg, driftOffset:number){
+  const cx = cfg.origin[0], cy = cfg.origin[1];
+  const pts:SpiralSample[] = [];
+  for (const tok of tokens){
+    const { r, theta } = phyllo(tok.k, cfg.baseR, cfg.wobble);
+    // clockwise spiral: invert angle sign
+    const th = -(theta + 0.06*t);
+    const { x, y } = polarToXY(r, th);
+    let px = x, py = y - driftOffset;  // bottom->top drift (subtract)
+    // apply teal torque toward ring
+    const tv = tealTorque(px+cx, py+cy, cfg);
+    px += tv.x; py += tv.y;
+    // monocle warp last
+    const w = monocleWarp(px+cx, py+cy, cfg);
+    // lock feedback
+    const rr = Math.hypot(w.x-cx, w.y-cy);
+    const locked = Math.abs(rr - cfg.teal.r) < 8;
+    pts.push({ token:tok, pos:{ x:w.x, y:w.y, th:th, locked } });
+  }
+  return pts;
+}
+

--- a/webapp_vr/src/phi/PhiJostleMonocle.tsx
+++ b/webapp_vr/src/phi/PhiJostleMonocle.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef, useState } from "react";
+import { stepFrame, type Token, type JostleCfg } from "./PhiJostleEngine";
+
+function hex(c:[number,number,number]){ return `rgb(${c[0]},${c[1]},${c[2]})`; }
+
+const ROAD:[number,number,number] = [245,205,70];
+const TEAL:[number,number,number] = [16,198,178];
+const BLUE:[number,number,number] = [80,150,255];
+const YG:[number,number,number] = [190,230,100];
+const RO:[number,number,number] = [255,110,60];
+
+const palette = [ROAD, BLUE, YG, RO];
+
+export default function PhiJostleMonocle(){
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const recRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const [cfg, setCfg] = useState<JostleCfg>({
+    width: 1024, height: 640,
+    origin: [40, 40],
+    baseR: 4.5, particles: 480, drift: 0.9,
+    wobble: 0.000437,
+    teal: { r: 260, soft: 0.62, hard: 0.72 },
+    monocle: { x: 420, y: 300, r: 120, arc: 0.9 }
+  });
+  const [tokens, setTokens] = useState<Token[]>(()=> demoTokens("Welcome to the Throng Spiral where letters remember their birth"));
+  const tRef = useRef(0); const driftRef = useRef(0);
+  const rafRef = useRef(0);
+
+  useEffect(()=>{
+    const cvs = canvasRef.current!;
+    const ctx = cvs.getContext("2d")!;
+    const render = ()=>{
+      const t = tRef.current++;
+      driftRef.current += cfg.drift;
+      ctx.clearRect(0,0,cfg.width,cfg.height);
+      // bg
+      ctx.fillStyle = "rgb(8,12,20)"; ctx.fillRect(0,0,cfg.width,cfg.height);
+      // teal ring
+      ctx.strokeStyle = hex(TEAL as any); ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(cfg.origin[0], cfg.origin[1], cfg.teal.r, 0, Math.PI*2); ctx.stroke();
+
+      const pts = stepFrame(tokens, t, cfg, driftRef.current);
+      // draw teal lattice nodes when locked
+      for (const s of pts){
+        if (s.pos.locked){
+          ctx.fillStyle = hex(TEAL as any);
+          ctx.fillRect(s.pos.x-1.2, s.pos.y-1.2, 2.4, 2.4);
+        }
+      }
+      // draw tokens
+      ctx.textAlign = "center"; ctx.textBaseline = "middle";
+      for (const s of pts){
+        const c = s.token.color;
+        const col = `rgba(${c[0]},${c[1]},${c[2]},0.92)`;
+        ctx.save();
+        ctx.translate(s.pos.x, s.pos.y);
+        ctx.rotate(s.pos.th);
+        ctx.font = `bold ${s.token.size}px system-ui`;
+        ctx.fillStyle = col;
+        ctx.fillText(s.token.text, 0, 0);
+        ctx.restore();
+      }
+      rafRef.current = requestAnimationFrame(render);
+    };
+    rafRef.current = requestAnimationFrame(render);
+    return ()=> cancelAnimationFrame(rafRef.current);
+  }, [cfg, tokens]);
+
+  const startRec = ()=>{
+    const cvs = canvasRef.current!;
+    const stream = (cvs as any).captureStream(30);
+    const rec = new MediaRecorder(stream, { mimeType: "video/webm;codecs=vp9" });
+    rec.ondataavailable = e => { if (e.data.size) chunksRef.current.push(e.data); };
+    rec.onstop = ()=>{
+      const blob = new Blob(chunksRef.current, { type: "video/webm" });
+      chunksRef.current = [];
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = "phi_jostle_demo.webm";
+      a.click();
+    };
+    recRef.current = rec; rec.start();
+  };
+  const stopRec = ()=> recRef.current?.stop();
+
+  return (
+    <div style={{position:"relative"}}>
+      <canvas ref={canvasRef} width={cfg.width} height={cfg.height} style={{width:"100%", background:"#080c14", border:"1px solid #1b2736", borderRadius:12}}/>
+      <div style={{position:"absolute", left:12, top:12, display:"flex", gap:8}}>
+        <button onClick={startRec}>Record</button>
+        <button onClick={stopRec}>Stop</button>
+        <button onClick={()=>setTokens(demoTokens(prompt("Enter text:", "Emergent language through φ‑jostle")||""))}>Load Text</button>
+        <button onClick={()=>setCfg({...cfg, monocle:{...cfg.monocle, x: cfg.monocle.x+30}})}>Nudge Monocle →</button>
+      </div>
+    </div>
+  );
+}
+
+function demoTokens(text:string){
+  // Wizard-of-Oz tokenizer: split to word-bubbles + a few glyphs
+  const words = text.split(/\s+/).filter(Boolean).slice(0, 64);
+  const tokens = [] as Token[];
+  let k = 0;
+  for (const w of words){
+    const color = k%4===0? ROAD : (k%4===1? BLUE : (k%4===2? YG : RO));
+    const size = 12 + Math.min(22, Math.floor(Math.sqrt(k+1)*1.6));
+    tokens.push({ text:w, k, color, size });
+    k += 7; // sparse along spiral to avoid overlap
+  }
+  return tokens;
+}
+

--- a/webapp_vr/src/routes/PhiMonocleRoute.tsx
+++ b/webapp_vr/src/routes/PhiMonocleRoute.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import PhiJostleMonocle from "../phi/PhiJostleMonocle";
+export default function PhiMonocleRoute(){
+  return (
+    <div style={{padding:12}}>
+      <h3 style={{color:"#eaf2ff"}}>Phi‑Jostle Monocle (Wizard‑of‑Oz)</h3>
+      <p style={{color:"#9fb4cc"}}>Upper‑left origin, bottom→top drift, clockwise spiral, teal cancel net, monocle glassfold.</p>
+      <PhiJostleMonocle/>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement PhiJostleEngine for golden phyllotaxis spiral, monocle glassfold, and teal cancel net
- add PhiJostleMonocle canvas UI with recording, text loading, and monocle control
- wire PhiMonocleRoute into App and document setup

## Testing
- `npm test`
- `npx tsc src/ghost/__tests__/GhostCore.test.ts --module commonjs --target ES2019 --outDir dist-test && node -e "require('fs').writeFileSync('dist-test/package.json','{\"type\":\"commonjs\"}')" && node dist-test/ghost/__tests__/GhostCore.test.js`
- `pnpm --filter webapp_vr test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e2cfa66483279968b5e209703332