### PR TITLE
Jostle Planner — Passive Streams Strategist (phi-jostle + multi-objective search)

### DIFF
--- a/webapp_vr/src/App.tsx
+++ b/webapp_vr/src/App.tsx
@@ -1,9 +1,3 @@
 import React from "react";
-import PhiMonocleRoute from "./routes/PhiMonocleRoute";
-export default function App(){
-  return (
-    <div style={{width:"100%",height:"100%",background:"#060a10"}}>
-      <PhiMonocleRoute/>
-    </div>
-  );
-}
+import StrategyRoute from "./routes/StrategyRoute";
+export default function App(){ return <StrategyRoute/>; }

--- a/webapp_vr/src/components/StrategyBoard.tsx
+++ b/webapp_vr/src/components/StrategyBoard.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { Weights } from "../strategy/Scoring";
+import workerUrl from "../strategy/worker/OptimizerWorker.ts?worker&url";
+
+type Best = { plan: any; total: number };
+const DEF_W: Weights = { profit:1.0, effort:1.2, ttf:0.9, risk:0.8, leverage:1.0, harmony:0.7 };
+
+export default function StrategyBoard(){
+  const [seed, setSeed] = useState("Passive income app for creators using assets I already have");
+  const [assets, setAssets] = useState("200 blog posts\n50 paintings\nopen-source repo\nsmall email list");
+  const [w, setW] = useState<Weights>(DEF_W);
+  const [best, setBest] = useState<Best[]>([]);
+  const [running, setRunning] = useState(false);
+  const wkRef = useRef<Worker|null>(null);
+
+  const run = ()=>{
+    if (running) return;
+    const wk = new Worker(workerUrl, { type:"module" });
+    wkRef.current = wk;
+    setRunning(true); setBest([]);
+    wk.onmessage = (e:any)=>{
+      if (e.data.type === "progress") setBest(e.data.best);
+      if (e.data.type === "done"){ setBest(e.data.best); setRunning(false); wk.terminate(); }
+    };
+    wk.postMessage({
+      seed, weights:w,
+      assets: assets.split(/\n+/).filter(Boolean),
+      beam: 14, iters: 60, maxPlans: 8
+    });
+  };
+  const stop = ()=>{ wkRef.current?.terminate(); setRunning(false); };
+
+  const exportMd = ()=>{
+    const lines:string[] = [];
+    lines.push(`# Jostle Planner — Top Strategies`);
+    best.forEach((b,i)=>{
+      const p = b.plan;
+      lines.push(`\n## ${i+1}. ${p.title}  \n**Score:** ${(b.total*100).toFixed(1)}%  \n${p.summary}`);
+      lines.push(`\n**Channels:** ${p.channels.join(", ")}`);
+      lines.push(`\n**Reuse:** ${p.reuse.join(", ")}`);
+      lines.push(`\n**Estimates:** revenue~$${Math.round(p.est.revenue)} · hours~${Math.round(p.est.hours)} · TTF~${Math.round(p.est.ttfDays)}d · risk~${p.est.risk.toFixed(2)}`);
+      lines.push(`\n**Steps:**\n${p.steps.map((s:string,i:number)=>`  ${i+1}. ${s}`).join("\n")}`);
+    });
+    const blob = new Blob([lines.join("\n")], {type:"text/markdown"});
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "jostle_planner_strategies.md";
+    a.click();
+  };
+
+  const W = (k:keyof Weights)=>(
+    <div><label>{k} <input type="number" step="0.1" value={(w as any)[k]}
+      onChange={e=>setW({...w, [k]: +e.target.value || 0})}/></label></div>
+  );
+
+  return (
+    <div style={{display:"grid", gridTemplateColumns:"320px 1fr", gap:12}}>
+      <div style={{background:"#0a0f15", color:"#eaf2ff", border:"1px solid #1b2736", borderRadius:12, padding:12}}>
+        <h3>Jostle Planner</h3>
+        <textarea value={seed} onChange={e=>setSeed(e.target.value)} rows={5} style={{width:"100%", background:"#0f1622", color:"#eaf2ff"}} />
+        <div style={{marginTop:8}}>
+          <div style={{fontWeight:600, marginBottom:4}}>My existing assets</div>
+          <textarea value={assets} onChange={e=>setAssets(e.target.value)} rows={6} style={{width:"100%", background:"#0f1622", color:"#eaf2ff"}} />
+        </div>
+        <div style={{display:"grid", gridTemplateColumns:"1fr 1fr", gap:6, marginTop:8}}>
+          {W("profit")}{W("effort")}{W("ttf")}{W("risk")}{W("leverage")}{W("harmony")}
+        </div>
+        <div style={{display:"flex", gap:8, marginTop:10}}>
+          <button onClick={run} disabled={running}>Run</button>
+          <button onClick={stop} disabled={!running}>Stop</button>
+          <button onClick={exportMd} disabled={!best.length}>Export</button>
+        </div>
+        <p style={{opacity:.75, marginTop:8}}>Runs entirely in your browser (Web Worker). No network.</p>
+      </div>
+      <div>
+        {best.map((b,i)=> <PlanCard key={i} rank={i+1} total={b.total} plan={b.plan}/>)}
+      </div>
+    </div>
+  );
+}
+
+function PlanCard({rank,total,plan}:{rank:number; total:number; plan:any}){
+  return (
+    <div style={{background:"#0d141e", color:"#eaf2ff", border:"1px solid #1b2736", borderRadius:12, padding:12, marginBottom:10}}>
+      <div style={{display:"flex", justifyContent:"space-between", alignItems:"baseline"}}>
+        <h4 style={{margin:0}}>{rank}. {plan.title}</h4>
+        <div style={{opacity:.9}}>Score {(total*100).toFixed(1)}%</div>
+      </div>
+      <div style={{opacity:.85, marginTop:4}}>{plan.summary}</div>
+      <div style={{marginTop:8}}><b>Channels:</b> {plan.channels.join(", ")}</div>
+      <div style={{marginTop:4}}><b>Reuse:</b> {plan.reuse.join(", ")}</div>
+      <div style={{marginTop:4}}><b>Est:</b> ${Math.round(plan.est.revenue)} · {Math.round(plan.est.hours)}h · {Math.round(plan.est.ttfDays)}d · risk {plan.est.risk.toFixed(2)}</div>
+      <ol style={{marginTop:8}}>
+        {plan.steps.map((s:string,idx:number)=><li key={idx}>{s}</li>)}
+      </ol>
+    </div>
+  );
+}

--- a/webapp_vr/src/docs/README_STRATEGY.md
+++ b/webapp_vr/src/docs/README_STRATEGY.md
@@ -1,0 +1,4 @@
+# Jostle Planner
+- Pure client-side multi-objective optimizer (Web Worker).
+- Objectives: profit↑, effort↓, time-to-first-dollar↓, risk↓, leverage↑, harmony(TEAL)↑.
+- Weights adjustable. Paste your assets; press Run; export Markdown.

--- a/webapp_vr/src/routes/StrategyRoute.tsx
+++ b/webapp_vr/src/routes/StrategyRoute.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import StrategyBoard from "../components/StrategyBoard";
+export default function StrategyRoute(){
+  return (
+    <div style={{padding:12}}>
+      <h3 style={{color:"#eaf2ff"}}>Jostle Planner — Passive Streams Strategist</h3>
+      <p style={{color:"#9fb4cc"}}>Seed → concept graph → beam search → top strategies (Profit/Effort/TTF/Risk/Leverage/Harmony)</p>
+      <StrategyBoard/>
+    </div>
+  );
+}

--- a/webapp_vr/src/strategy/Scoring.ts
+++ b/webapp_vr/src/strategy/Scoring.ts
@@ -1,0 +1,37 @@
+// Multi-objective scoring (all 0..1 where higher is better, except risk)
+export type Weights = {
+  profit:number; effort:number; ttf:number; risk:number; leverage:number; harmony:number;
+};
+export type Scores = {
+  profit:number; effort:number; ttf:number; risk:number; leverage:number; harmony:number;
+};
+export type Plan = {
+  id:string; title:string; summary:string;
+  steps:string[]; channels:string[]; reuse:string[];
+  est:{ revenue:number; hours:number; ttfDays:number; risk:number };
+  features:number[];           // embedding-ish vector
+  notes?:string;
+};
+export function normalize(v:number, lo:number, hi:number){ return Math.max(0, Math.min(1, (v-lo)/(hi-lo+1e-9))); }
+
+export function scorePlan(p:Plan, w:Weights): {scores:Scores; total:number} {
+  const profit   = normalize(p.est.revenue,  100, 50000);          // tune windows
+  const effort   = 1 - normalize(p.est.hours, 4, 400);
+  const ttf      = 1 - normalize(p.est.ttfDays, 1, 180);
+  const risk     = 1 - Math.max(0, Math.min(1, p.est.risk));       // risk lower is better
+  const leverage = Math.min(1, p.reuse.length / 8);                 // more reuse → higher leverage
+  const harmony  = estimateHarmony(p);                              // TEAL-ish proxy 0..1
+  const scores:Scores = { profit, effort, ttf, risk, leverage, harmony };
+  const total = (w.profit*profit + w.effort*effort + w.ttf*ttf + w.risk*risk + w.leverage*leverage + w.harmony*harmony) /
+                (w.profit + w.effort + w.ttf + w.risk + w.leverage + w.harmony + 1e-9);
+  return { scores, total };
+}
+
+// Cheap proxy for harmony: balanced channels + modest step fan-out + diversified reuse
+function estimateHarmony(p:Plan): number {
+  const ch = new Set(p.channels.map(s => s.split(":")[0]));
+  const balance = Math.min(1, ch.size/4);
+  const stepPenalty = Math.max(0, 1 - (Math.max(0, p.steps.length - 7)/7));
+  const reuseSpread = Math.min(1, p.reuse.length/6);
+  return 0.4*balance + 0.35*stepPenalty + 0.25*reuseSpread;
+}

--- a/webapp_vr/src/strategy/TextFeatures.ts
+++ b/webapp_vr/src/strategy/TextFeatures.ts
@@ -1,0 +1,34 @@
+// Lightweight tokenizer + co-occur graph + hashed n-gram features (no heavy deps)
+export function tokenize(s:string){ return (s.toLowerCase().match(/[a-z0-9'\-]+/g)||[]).slice(0,256); }
+export function ngrams(tokens:string[], n=3){
+  const grams:string[] = [];
+  for (let i=0;i<tokens.length;i++){
+    for (let k=1;k<=n;k++){
+      const t = tokens.slice(i,i+k).join(" ");
+      if (t) grams.push(t);
+    }
+  }
+  return grams;
+}
+export function hashVec(grams:string[], dim=64){
+  const v=new Array(dim).fill(0);
+  for (const g of grams){
+    let h=2166136261;
+    for (let i=0;i<g.length;i++){ h ^= g.charCodeAt(i); h += (h<<1)+(h<<4)+(h<<7)+(h<<8)+(h<<24); }
+    const idx = Math.abs(h|0) % dim;
+    v[idx] += 1;
+  }
+  const norm = Math.sqrt(v.reduce((a,c)=>a+c*c,0))||1;
+  return v.map(x=>x/norm);
+}
+export function cosine(a:number[], b:number[]){ let s=0; for (let i=0;i<a.length;i++) s+=a[i]*b[i]; return s; }
+export function cooccur(tokens:string[], window=3){
+  const edges = new Map<string, number>();
+  for (let i=0;i<tokens.length;i++){
+    for (let j=i+1;j<Math.min(tokens.length, i+1+window); j++){
+      const key = tokens[i] < tokens[j] ? tokens[i]+"|"+tokens[j] : tokens[j]+"|"+tokens[i];
+      edges.set(key, (edges.get(key)||0)+1);
+    }
+  }
+  return edges;
+}

--- a/webapp_vr/src/strategy/worker/OptimizerWorker.ts
+++ b/webapp_vr/src/strategy/worker/OptimizerWorker.ts
@@ -1,0 +1,95 @@
+import { tokenize, ngrams, hashVec, cosine } from "../TextFeatures";
+import { scorePlan, type Weights, type Plan } from "../Scoring";
+
+export type WorkMsg = { seed:string; weights:Weights; assets:string[]; beam:number; iters:number; maxPlans:number };
+export type ResMsg  = { type:"progress"|"done"; best: {plan:Plan; total:number}[] };
+
+function makeSeeds(seed:string, assets:string[]): Plan[] {
+  const tok = tokenize(seed);
+  const grams = ngrams(tok, 3);
+  const base = hashVec(grams, 64);
+  const channels = ["content:yt","content:shorts","app:ios","app:web","course:gumroad","licensing:api","affiliate:blog","print:on-demand"];
+  const reuse = assets.slice(0, 8);
+  const variants: Plan[] = [];
+  for (let i=0;i<8;i++){
+    const steps = [
+      "Validate demand with 3 micro-posts",
+      "Ship MVP landing (Netlify)",
+      "Automate capture + email",
+      "Repurpose into 4 channels",
+      "Price test 3 tiers",
+      "Spin royalty hooks"
+    ];
+    variants.push({
+      id: "seed-"+i,
+      title: "Seeded Strategy "+(i+1),
+      summary: "Combine MVP + content flywheel + light automation",
+      steps,
+      channels: channels.slice(0, 3 + (i%4)),
+      reuse,
+      est: { revenue: 5000 + i*1500, hours: 60 + i*20, ttfDays: 21 - i*2, risk: 0.35 + 0.05*i },
+      features: base.map((v,idx)=> v * (1 + 0.01*(i-4) * Math.cos(idx)))
+    });
+  }
+  return variants;
+}
+
+function neighbor(p:Plan, seedVec:number[]): Plan {
+  const pick = Math.random();
+  const clone = JSON.parse(JSON.stringify(p)) as Plan;
+  if (pick < 0.33) {
+    // tweak channels
+    const all = ["content:yt","content:shorts","newsletter","app:ios","app:web","course:gumroad","licensing:api","affiliate:blog","ugc:tiktok"];
+    if (Math.random()<0.5 && clone.channels.length>2) clone.channels.pop();
+    else if (clone.channels.length<6) clone.channels.push(all[Math.floor(Math.random()*all.length)]);
+  } else if (pick < 0.66) {
+    // tweak steps
+    if (Math.random()<0.5 && clone.steps.length>4) clone.steps.pop();
+    else clone.steps.push("Automate fulfillment / Zapier pass");
+  } else {
+    // tweak estimates
+    clone.est.revenue *= (0.9 + 0.25*Math.random());
+    clone.est.hours   *= (0.8 + 0.25*Math.random());
+    clone.est.ttfDays *= (0.8 + 0.25*Math.random());
+    clone.est.risk    = Math.min(1, Math.max(0, clone.est.risk + (Math.random()-0.5)*0.2));
+  }
+  // slight drift of features toward seedVec
+  clone.features = clone.features.map((v,i)=> v*0.98 + seedVec[i]*0.02);
+  return clone;
+}
+
+self.onmessage = (e:MessageEvent<WorkMsg>)=>{
+  const { seed, weights, assets, beam, iters, maxPlans } = e.data;
+  const tok = tokenize(seed);
+  const grams = ngrams(tok, 3);
+  const seedVec = hashVec(grams, 64);
+
+  let pool:Plan[] = makeSeeds(seed, assets);
+  let scored = pool.map(p => ({ plan:p, ...scorePlan(p, weights) }));
+  scored.sort((a,b)=> b.total - a.total);
+  let best = scored.slice(0, Math.min(beam, scored.length));
+
+  for (let t=0; t<iters; t++){
+    const candidates:Plan[] = [];
+    for (const b of best){
+      for (let k=0;k<4;k++){ candidates.push(neighbor(b.plan, seedVec)); }
+    }
+    const resc = candidates.map(p => ({ plan:p, ...scorePlan(p, weights) }));
+    const merged = [...best, ...resc];
+    merged.sort((a,b)=> b.total - a.total);
+    // de-dup similar plans by cosine features
+    const pruned: typeof merged = [];
+    for (const m of merged){
+      let keep = true;
+      for (const q of pruned){
+        const sim = cosine(m.plan.features, q.plan.features);
+        if (sim > 0.97){ keep = false; break; }
+      }
+      if (keep) pruned.push(m);
+      if (pruned.length >= beam) break;
+    }
+    best = pruned;
+    if (t % 5 === 0) (self as any).postMessage({ type:"progress", best: best.slice(0, Math.min(maxPlans, best.length)) });
+  }
+  (self as any).postMessage({ type:"done", best: best.slice(0, Math.min(maxPlans, best.length)) });
+};


### PR DESCRIPTION
## Summary
- Add multi-objective scoring utilities for profit, effort, time-to-first-dollar, risk, leverage, and harmony.
- Implement Optimizer web worker that seeds strategies, explores neighbors, and reports top plans via beam search.
- Create Strategy Board UI with seed/asset inputs, weight controls, worker execution, and Markdown export.

## Testing
- `pre-commit run --files webapp_vr/src/strategy/Scoring.ts webapp_vr/src/strategy/TextFeatures.ts webapp_vr/src/strategy/worker/OptimizerWorker.ts webapp_vr/src/components/StrategyBoard.tsx webapp_vr/src/routes/StrategyRoute.tsx webapp_vr/src/App.tsx webapp_vr/src/docs/README_STRATEGY.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Proxy connection 403)*
- `pnpm -F webapp_vr build` *(fails: unable to download pnpm due to proxy 403)*
- `pnpm -F webapp_vr test` *(fails: unable to download pnpm due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e6d6a6ac83279a33ec8ef26f9339