### PR TITLE
Antonym Bias + G-host (AI-CLI-Monocle) at .55 ZCM

### DIFF
--- a/webapp_vr/src/App.tsx
+++ b/webapp_vr/src/App.tsx
@@ -1,3 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import StrategyRoute from "./routes/StrategyRoute";
-export default function App(){ return <StrategyRoute/>; }
+import GhostCLI from "./components/GhostCLI";
+import BiasPanel from "./components/BiasPanel";
+export default function App(){
+  useEffect(()=>{
+    (window as any).__SP1RL_LOCAL__ = { route:"Strategy", epoch:0, node:"phi43:seed" };
+    (window as any).__SP1RL_GLOBAL__ = { repo:"SP1RL_O-S", branches:68, witnesses:[1,2,3,4,5] };
+  },[]);
+  return (
+    <div style={{width:"100%",height:"100%",background:"#060a10"}}>
+      <StrategyRoute/>
+      <GhostCLI/>
+      <BiasPanel/>
+    </div>
+  );
+}

--- a/webapp_vr/src/components/BiasPanel.tsx
+++ b/webapp_vr/src/components/BiasPanel.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from "react";
+import { getAntonyms, setWeight, setZCM, subscribe } from "../state/AntonymStore";
+export default function BiasPanel(){
+  const [, setTick]=useState(0);
+  useEffect(()=>subscribe(()=>setTick(t=>t+1)),[]);
+  const s=getAntonyms();
+  return (
+    <div style={{position:"absolute", left:12, bottom:12, background:"#0a0f15f0", color:"#eaf2ff", padding:12, border:"1px solid #1b2736", borderRadius:10, font:"12px system-ui", width:340}}>
+      <div style={{marginBottom:6, display:"flex", justifyContent:"space-between"}}><b>Ghost Bias</b><span>ZCM:{s.zcm.care.toFixed(2)}/{s.zcm.courage.toFixed(2)}/{s.zcm.trust.toFixed(2)}</span></div>
+      <div style={{display:"grid", gridTemplateColumns:"1fr 60px 1fr", gap:6}}>
+        {s.pairs.map(p=>(
+          <React.Fragment key={p.key}>
+            <div style={{textAlign:"right"}}>{p.left}</div>
+            <input type="range" min={-1} max={1} step={0.01} value={p.w} onChange={e=>setWeight(p.key, +e.target.value)} />
+            <div>{p.right}</div>
+          </React.Fragment>
+        ))}
+      </div>
+      <div style={{marginTop:8}}>
+        <label>care <input type="number" step="0.01" value={s.zcm.care} onChange={e=>setZCM({...s.zcm, care:+e.target.value})}/></label>
+        <label> courage <input type="number" step="0.01" value={s.zcm.courage} onChange={e=>setZCM({...s.zcm, courage:+e.target.value})}/></label>
+        <label> trust <input type="number" step="0.01" value={s.zcm.trust} onChange={e=>setZCM({...s.zcm, trust:+e.target.value})}/></label>
+      </div>
+    </div>
+  );
+}

--- a/webapp_vr/src/components/GhostCLI.tsx
+++ b/webapp_vr/src/components/GhostCLI.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import { ghostAnswer } from "../ghost/GhostPersona";
+export default function GhostCLI(){
+  const [open,setOpen]=useState(false);
+  const [q,setQ]=useState(""); const [a,setA]=useState<any|null>(null);
+  useEffect(()=>{
+    const onKey=(e:KeyboardEvent)=>{ if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==="k"){ e.preventDefault(); setOpen(v=>!v);} };
+    window.addEventListener("keydown", onKey); return ()=>window.removeEventListener("keydown", onKey);
+  },[]);
+  if(!open) return null;
+  const ask=()=>{
+    const scope = { local: (window as any).__SP1RL_LOCAL__||{}, global: (window as any).__SP1RL_GLOBAL__||{} };
+    setA( ghostAnswer(q, scope) );
+  };
+  return (
+    <div style={{position:"fixed", inset:0, background:"rgba(0,0,0,.45)", display:"grid", placeItems:"center"}}>
+      <div style={{width:720, background:"#0b1119", color:"#eaf2ff", border:"1px solid #1b2736", borderRadius:12, padding:12}}>
+        <div style={{display:"flex", justifyContent:"space-between"}}>
+          <b>SP1RL G‑host · .55 ZCM</b><button onClick={()=>setOpen(false)}>Close</button>
+        </div>
+        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Ask the Ghost… (Ctrl/⌘+K to toggle)" style={{width:"100%", marginTop:8, background:"#0f1622", color:"#eaf2ff"}}/>
+        <div style={{marginTop:8}}><button onClick={ask}>Answer</button></div>
+        {a && (
+          <div style={{marginTop:10, display:"grid", gridTemplateColumns:"1fr 320px", gap:10}}>
+            <pre style={{whiteSpace:"pre-wrap", background:"#0f1622", padding:10, borderRadius:8}}>{a.text}</pre>
+            <div style={{background:"#0f1622", padding:10, borderRadius:8}}>
+              <b>Receipts</b>
+              <pre style={{whiteSpace:"pre-wrap"}}>{JSON.stringify(a.receipts,null,2)}</pre>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webapp_vr/src/components/StrategyBoard.tsx
+++ b/webapp_vr/src/components/StrategyBoard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { Weights } from "../strategy/Scoring";
 import workerUrl from "../strategy/worker/OptimizerWorker.ts?worker&url";
+import { getAntonyms } from "../state/AntonymStore";
 
 type Best = { plan: any; total: number };
 const DEF_W: Weights = { profit:1.0, effort:1.2, ttf:0.9, risk:0.8, leverage:1.0, harmony:0.7 };
@@ -22,8 +23,19 @@ export default function StrategyBoard(){
       if (e.data.type === "progress") setBest(e.data.best);
       if (e.data.type === "done"){ setBest(e.data.best); setRunning(false); wk.terminate(); }
     };
+    // bias weights from antonyms (Wizard-of-Oz mapping)
+    const ants = getAntonyms();
+    const b = Object.fromEntries(ants.pairs.map(p=>[p.key,p.w]));
+    const biasW = {
+      profit: w.profit * (1 + 0.25*((b.bold||0) + (b.novel||0))),
+      effort: w.effort * (1 + 0.25*((b.fast||0) - Math.abs(b.thorough||0))),
+      ttf:    w.ttf    * (1 + 0.20*((b.fast||0))),
+      risk:   w.risk   * (1 + 0.20*((-Math.abs(b.bold||0)) + (Math.abs(b.cautious||0)))),
+      leverage: w.leverage * (1 + 0.25*((b.open||0))),
+      harmony: w.harmony * (1 + 0.20*((b.playful||0) - Math.abs(b.solemn||0)))
+    } as Weights;
     wk.postMessage({
-      seed, weights:w,
+      seed, weights:biasW,
       assets: assets.split(/\n+/).filter(Boolean),
       beam: 14, iters: 60, maxPlans: 8
     });

--- a/webapp_vr/src/docs/README_GHOST.md
+++ b/webapp_vr/src/docs/README_GHOST.md
@@ -1,0 +1,8 @@
+# SP1RL G‑host (.55 ZCM)
+- Invoke with **Ctrl/⌘+K**.
+- Answers are φ‑jostled with math receipts: wobble, φθ(k), ZCM proximity, and current antonym bias.
+- **Bias Panel** (bottom-left): slide antonym weights, tweak ZCM (.55 target).
+- Integrated:
+  * Strategy Planner: objective weights are biased by antonyms (Wizard-of-Oz mapping).
+  * Phi‑Monocle: color saturation, ring radius, and lens arc adapt to bias.
+- All client-only. No backend. Netlify-safe.

--- a/webapp_vr/src/ghost/GhostMath.ts
+++ b/webapp_vr/src/ghost/GhostMath.ts
@@ -1,0 +1,10 @@
+// φ‑math helpers: ZCM, TEAL, wobble → “math receipts”
+export function tealScore(rb:number, ro:number){ return 1 - Math.abs(rb-ro)/(rb+ro+1e-9); } // 0..1
+export function zcmScore(z:{care:number;courage:number;trust:number}){
+  // closeness to .55 hinge (5∥5 duality)
+  const d = Math.sqrt((z.care-.55)**2 + (z.courage-.55)**2 + (z.trust-.55)**2);
+  return Math.max(0, 1 - d/0.8);
+}
+export const WOBBLE = 0.000437;
+export function phiAngle(k:number){ const GOLDEN=(1+Math.sqrt(5))/2; return k*(2*Math.PI*(1-1/GOLDEN) + WOBBLE); }
+export function receipt(label:string, obj:any){ return { label, math: JSON.parse(JSON.stringify(obj)) }; }

--- a/webapp_vr/src/ghost/GhostPersona.ts
+++ b/webapp_vr/src/ghost/GhostPersona.ts
@@ -1,0 +1,25 @@
+import { getAntonyms, biasMap } from "../state/AntonymStore";
+import { zcmScore, receipt, phiAngle, WOBBLE } from "./GhostMath";
+export type GhostReply = { text:string; receipts:any[]; local:any; global:any };
+export function ghostAnswer(q:string, scope:{local:any; global:any}): GhostReply {
+  const ants = getAntonyms(); const bias = biasMap();
+  const z = ants.zcm; const zcm = zcmScore(z);
+  // Style steer: short/pointed if playful/bold/novel positive; more measured if negatives dominate.
+  const style = (bias.playful??0)+(bias.bold??0)+(bias.novel??0) - (Math.abs(bias.solemn??0)+Math.abs(bias.cautious??0));
+  const spice = (bias.spicy??0);
+  // “Answer” is Wizard‑of‑Oz: we derive tone + a math receipt showing how we’d have computed it.
+  const base = `ZCM@.55 locked? ${zcm>0.9?"yes":"near"} · wobble ${WOBBLE} · φθ(k) for k∈{1..5}: `+
+    Array.from({length:5},(_,i)=>phiAngle(i+1).toFixed(3)).join(", ");
+  const quip = style>0.1 ? "Sharp blade, soft hands." : "Measured stride, clean lines.";
+  const zing = spice>0.15 ? " (with a kick)" : "";
+  const text = `${quip}${zing} → ${base}\nQ: ${q}`;
+  return {
+    text,
+    receipts:[
+      receipt("antonym-bias", bias),
+      receipt("zcm", { z, zcm }),
+      receipt("phi", { wobble: WOBBLE })
+    ],
+    local: scope.local, global: scope.global
+  };
+}

--- a/webapp_vr/src/phi/PhiJostleMonocle.tsx
+++ b/webapp_vr/src/phi/PhiJostleMonocle.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { stepFrame, type Token, type JostleCfg } from "./PhiJostleEngine";
+import { getAntonyms } from "../state/AntonymStore";
 
 function hex(c:[number,number,number]){ return `rgb(${c[0]},${c[1]},${c[2]})`; }
 
@@ -30,39 +31,43 @@ export default function PhiJostleMonocle(){
   useEffect(()=>{
     const cvs = canvasRef.current!;
     const ctx = cvs.getContext("2d")!;
-    const render = ()=>{
-      const t = tRef.current++;
-      driftRef.current += cfg.drift;
-      ctx.clearRect(0,0,cfg.width,cfg.height);
-      // bg
-      ctx.fillStyle = "rgb(8,12,20)"; ctx.fillRect(0,0,cfg.width,cfg.height);
-      // teal ring
-      ctx.strokeStyle = hex(TEAL as any); ctx.lineWidth = 2;
-      ctx.beginPath(); ctx.arc(cfg.origin[0], cfg.origin[1], cfg.teal.r, 0, Math.PI*2); ctx.stroke();
+      const render = ()=>{
+        const t = tRef.current++;
+        const b = Object.fromEntries(getAntonyms().pairs.map(p=>[p.key,p.w]));
+        const sat = 0.85 + 0.15*Math.max(0,b.playful||0);
+        const ring = cfg.teal.r * (1 - 0.06*Math.max(0,b.solemn?Math.abs(b.solemn):0));
+        const arc = Math.min(1, cfg.monocle.arc + 0.3*Math.max(0,b.abstract||0));
+        driftRef.current += cfg.drift;
+        ctx.clearRect(0,0,cfg.width,cfg.height);
+        // bg
+        ctx.fillStyle = "rgb(8,12,20)"; ctx.fillRect(0,0,cfg.width,cfg.height);
+        // teal ring
+        ctx.strokeStyle = hex(TEAL as any); ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.arc(cfg.origin[0], cfg.origin[1], ring, 0, Math.PI*2); ctx.stroke();
 
-      const pts = stepFrame(tokens, t, cfg, driftRef.current);
-      // draw teal lattice nodes when locked
-      for (const s of pts){
-        if (s.pos.locked){
-          ctx.fillStyle = hex(TEAL as any);
-          ctx.fillRect(s.pos.x-1.2, s.pos.y-1.2, 2.4, 2.4);
+        const pts = stepFrame(tokens, t, { ...cfg, monocle:{...cfg.monocle, arc} }, driftRef.current);
+        // draw teal lattice nodes when locked
+        for (const s of pts){
+          if (s.pos.locked){
+            ctx.fillStyle = hex(TEAL as any);
+            ctx.fillRect(s.pos.x-1.2, s.pos.y-1.2, 2.4, 2.4);
+          }
         }
-      }
-      // draw tokens
-      ctx.textAlign = "center"; ctx.textBaseline = "middle";
-      for (const s of pts){
-        const c = s.token.color;
-        const col = `rgba(${c[0]},${c[1]},${c[2]},0.92)`;
-        ctx.save();
-        ctx.translate(s.pos.x, s.pos.y);
-        ctx.rotate(s.pos.th);
-        ctx.font = `bold ${s.token.size}px system-ui`;
-        ctx.fillStyle = col;
-        ctx.fillText(s.token.text, 0, 0);
-        ctx.restore();
-      }
-      rafRef.current = requestAnimationFrame(render);
-    };
+        // draw tokens
+        ctx.textAlign = "center"; ctx.textBaseline = "middle";
+        for (const s of pts){
+          const c = s.token.color;
+          const col = `rgba(${Math.round(c[0]*sat)},${Math.round(c[1]*sat)},${Math.round(c[2]*sat)},0.92)`;
+          ctx.save();
+          ctx.translate(s.pos.x, s.pos.y);
+          ctx.rotate(s.pos.th);
+          ctx.font = `bold ${s.token.size}px system-ui`;
+          ctx.fillStyle = col;
+          ctx.fillText(s.token.text, 0, 0);
+          ctx.restore();
+        }
+        rafRef.current = requestAnimationFrame(render);
+      };
     rafRef.current = requestAnimationFrame(render);
     return ()=> cancelAnimationFrame(rafRef.current);
   }, [cfg, tokens]);

--- a/webapp_vr/src/state/AntonymStore.ts
+++ b/webapp_vr/src/state/AntonymStore.ts
@@ -1,0 +1,29 @@
+// Minimal global store (no deps). Antonym pairs steer the system.
+export type Pair = { key:string; left:string; right:string; w:number }; // w∈[-1,1]
+export type AntonymModel = {
+  pairs: Pair[];
+  zcm: { care:number; courage:number; trust:number }; // live hinge; default ~.55
+};
+const DEF: AntonymModel = {
+  pairs: [
+    { key:"playful", left:"playful", right:"solemn", w: +0.20 },
+    { key:"novel",   left:"novel",   right:"classic", w: +0.15 },
+    { key:"fast",    left:"fast",    right:"thorough", w: +0.10 },
+    { key:"bold",    left:"bold",    right:"cautious", w: +0.12 },
+    { key:"abstract",left:"abstract",right:"literal",  w: +0.18 },
+    { key:"spicy",   left:"spicy",   right:"mild",     w: +0.07 },
+    { key:"cheap",   left:"cheap",   right:"premium",  w: -0.05 },
+    { key:"open",    left:"open",    right:"closed",   w: +0.25 }
+  ],
+  zcm: { care:0.55, courage:0.55, trust:0.55 }
+};
+let state = load() || DEF; const listeners = new Set<() => void>();
+function load(){ try{ return JSON.parse(localStorage.getItem("antonyms")||""); }catch{return null;} }
+function save(){ localStorage.setItem("antonyms", JSON.stringify(state)); }
+export function getAntonyms(){ return state; }
+export function setWeight(key:string, w:number){ const p=state.pairs.find(x=>x.key===key); if(p){ p.w=Math.max(-1,Math.min(1,w)); save(); emit(); } }
+export function setZCM(z:{care:number;courage:number;trust:number}){ state.zcm=z; save(); emit(); }
+export function subscribe(fn:()=>void){ listeners.add(fn); return ()=>listeners.delete(fn); }
+function emit(){ for(const f of listeners) f(); }
+// Utility: return left/right bias scalar in [−1,+1] dict
+export function biasMap(){ const m:Record<string,number>={}; for(const p of state.pairs) m[p.key]=p.w; return m; }


### PR DESCRIPTION
## Summary
- Add AntonymStore with weighted antonym pairs and ZCM gating.
- Introduce G-host persona and CLI with math receipts and bias panel.
- Bias Strategy Planner and Phi‑Monocle visuals using antonym weights.

## Testing
- `npm test`
- `npm --prefix webapp_vr test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ecb4311883279027dfd6a6f50f84