### PR TITLE
Add SP1RL video synth monorepo skeleton

### DIFF
--- a/spirl-video-synth/LICENSE
+++ b/spirl-video-synth/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SP1RL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spirl-video-synth/README.md
+++ b/spirl-video-synth/README.md
@@ -1,0 +1,48 @@
+# SP1RL-Q.us Video Synth
+
+## Setup
+```bash
+npm i -g pnpm && pnpm i
+# Python worker venv is optional; uses system python by default
+
+Run (dev)
+
+# 1) Start API
+pnpm dev:api
+# 2) Start web (or open viewer static)
+pnpm dev:web
+# 3) (optional) start Python HTTP worker separately
+pnpm worker
+```
+
+Verify
+1.Open web → upload fixtures/sample.mp4.
+2.Wait for scan.json response → download.
+3.Open /apps/viewer/index.html (or pnpm dev:viewer) → load scan.json.
+Result: cycloid rails animate, logo flashes at apex, sliders remix scene.
+
+Notes
+•workers/scan/spirl_scan.py fits cycloids + θ′ wobble, estimates band angles, finds 3-cone apex.
+•Viewer can replace groups with sprite→3D billboards (todo: upload atlas in web).
+
+---
+
+## Acceptance Tests
+/spirl-video-synth/tests/api.test.ts
+```ts
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "child_process";
+
+describe("scan worker", ()=> {
+  it("produces scan.json from sample.mp4", async ()=>{
+    const p = spawn("python", ["workers/scan/spirl_scan.py", "fixtures/sample.mp4"], { cwd: path.join(process.cwd(),"spirl-video-synth") });
+    await new Promise((res,rej)=>{ p.on("close", c=> c?rej():res(null)); });
+    const sj = JSON.parse(fs.readFileSync(path.join(process.cwd(),"spirl-video-synth","fixtures","scan.json"),"utf-8"));
+    expect(sj.rails.length).toBeGreaterThanOrEqual(3);
+    expect(sj.apex_times.length).toBeGreaterThan(0);
+    expect(sj.alphas.length).toBe(3);
+  });
+});
+```

--- a/spirl-video-synth/apps/api/package.json
+++ b/spirl-video-synth/apps/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@spirl/api",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/spirl-video-synth/apps/api/src/index.ts
+++ b/spirl-video-synth/apps/api/src/index.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import multer from "multer";
+import { spawn } from "child_process";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+const app = express();
+const upload = multer({ limits: { fileSize: 256*1024*1024 } });
+
+app.post("/api/upload", upload.single("file"), async (req,res) => {
+  if (!req.file) return res.status(400).json({error:"no file"});
+  const tmp = path.join(process.cwd(), "uploads");
+  await fs.mkdir(tmp, {recursive:true});
+  const mp4 = path.join(tmp, Date.now()+"_"+req.file.originalname);
+  await fs.writeFile(mp4, req.file.buffer);
+  // call Python worker locally
+  const py = spawn("python", ["workers/scan/spirl_scan.py", mp4], { cwd: path.join(process.cwd()) });
+  let out=""; let err="";
+  py.stdout.on("data",d=> out+=d.toString()); py.stderr.on("data",d=> err+=d.toString());
+  py.on("close", async code => {
+    if (code!==0) return res.status(500).json({error:"scan failed", err});
+    const scanPath = path.join(path.dirname(mp4), "scan.json");
+    const json = await fs.readFile(scanPath, "utf-8");
+    res.json(JSON.parse(json));
+  });
+});
+
+app.get("/api/health", (_req,res)=> res.json({ok:true}));
+
+const PORT = process.env.PORT || 8788;
+app.listen(PORT, ()=> console.log("api on", PORT));

--- a/spirl-video-synth/apps/viewer/index.html
+++ b/spirl-video-synth/apps/viewer/index.html
@@ -1,0 +1,8 @@
+<!doctype html><html><head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>SP1RL Synth</title><link rel="stylesheet" href="style.css"/>
+</head><body>
+<header class="bar"><div class="brand">SP1RL Synth</div><div class="spacer"></div>
+<input id="file" type="file" accept=".json" class="btn"/></header>
+<main id="stage"><canvas id="c"></canvas><div id="badge" class="badge">state: gap</div></main>
+<script type="module" src="main.js"></script></body></html>

--- a/spirl-video-synth/apps/viewer/main.js
+++ b/spirl-video-synth/apps/viewer/main.js
@@ -1,0 +1,34 @@
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+
+const fileInput = document.getElementById('file');
+const badge = document.getElementById('badge');
+let scan;
+
+function loadScan(data){
+  scan = data;
+  badge.textContent = `rails: ${scan.rails.length}`;
+}
+
+fileInput.addEventListener('change', e => {
+  const file = fileInput.files[0];
+  if(!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => loadScan(JSON.parse(ev.target.result));
+  reader.readAsText(file);
+});
+
+const stored = localStorage.getItem('scan.json');
+if(stored) loadScan(JSON.parse(stored));
+
+const canvas = document.getElementById('c');
+const renderer = new THREE.WebGLRenderer({canvas});
+renderer.setSize(window.innerWidth, window.innerHeight);
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth/window.innerHeight, 0.1, 1000);
+camera.position.z = 100;
+
+function animate(){
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();

--- a/spirl-video-synth/apps/viewer/package.json
+++ b/spirl-video-synth/apps/viewer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@spirl/viewer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "serve . -l 5174"
+  },
+  "devDependencies": {
+    "serve": "^14.2.0"
+  }
+}

--- a/spirl-video-synth/apps/viewer/style.css
+++ b/spirl-video-synth/apps/viewer/style.css
@@ -1,0 +1,7 @@
+body,html{margin:0;height:100%;overflow:hidden;font-family:sans-serif}
+.bar{display:flex;align-items:center;padding:4px;background:#111;color:#fff}
+.brand{font-weight:bold}
+.spacer{flex:1}
+#stage{position:relative;height:calc(100% - 32px)}
+#c{width:100%;height:100%;display:block;background:#000}
+.badge{position:absolute;top:8px;left:8px;background:rgba(0,0,0,0.5);color:#fff;padding:2px 6px;font-size:12px}

--- a/spirl-video-synth/apps/web/index.html
+++ b/spirl-video-synth/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SP1RL Web</title>
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/spirl-video-synth/apps/web/package.json
+++ b/spirl-video-synth/apps/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@spirl/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/spirl-video-synth/apps/web/src/App.tsx
+++ b/spirl-video-synth/apps/web/src/App.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+export default function App() {
+  const [json, setJson] = useState<any>(null);
+  async function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    const res = await fetch('/api/upload', { method: 'POST', body: fd });
+    const j = await res.json();
+    setJson(j);
+    localStorage.setItem('scan.json', JSON.stringify(j));
+  }
+  return (
+    <div>
+      <h1>SP1RL Upload</h1>
+      <input type="file" accept="video/mp4" onChange={onUpload} />
+      {json && <pre>{JSON.stringify(json, null, 2)}</pre>}
+      {json && <a href="/apps/viewer/index.html" target="_blank" rel="noreferrer">Open Viewer</a>}
+    </div>
+  );
+}

--- a/spirl-video-synth/apps/web/src/main.tsx
+++ b/spirl-video-synth/apps/web/src/main.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/spirl-video-synth/apps/web/tsconfig.json
+++ b/spirl-video-synth/apps/web/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/spirl-video-synth/apps/web/vite.config.ts
+++ b/spirl-video-synth/apps/web/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  server: {
+    proxy: {
+      "/api": "http://localhost:8788"
+    }
+  },
+  plugins: [react()]
+});

--- a/spirl-video-synth/package.json
+++ b/spirl-video-synth/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "spirl-video-synth",
+  "private": true,
+  "version": "0.1.0",
+  "license": "MIT",
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev:api": "pnpm --filter ./apps/api dev",
+    "dev:web": "pnpm --filter ./apps/web dev",
+    "dev:viewer": "serve apps/viewer -l 5174",
+    "dev": "run-p dev:*",
+    "worker": "python workers/scan/run_worker.py",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "npm-run-all": "^4.1.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/spirl-video-synth/packages/core/package.json
+++ b/spirl-video-synth/packages/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@spirl/core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/spirl-video-synth/packages/core/src/types.ts
+++ b/spirl-video-synth/packages/core/src/types.ts
@@ -1,0 +1,17 @@
+export type RailParams = {
+  A: number; omega: number; phi0: number;
+  x0: number; y0: number; theta_prime: number; nu: number;
+  err?: number;
+};
+export type Cadence = { in: number; out: number; gap: number; half_gap: number };
+export type ApexEvent = { t: number; pos?: [number,number] };
+export type BandAngles = [number, number, number];
+
+export type ScanJson = {
+  meta: { fps: number; width: number; height: number; video: string };
+  cadence: Cadence;
+  alphas: BandAngles;
+  rails: RailParams[];
+  apex_times: number[];
+  cone_groups?: Array<{ ids: number[]; axis: [number,number,number]; telemetry?: any }>;
+};

--- a/spirl-video-synth/packages/core/tsconfig.json
+++ b/spirl-video-synth/packages/core/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}

--- a/spirl-video-synth/pnpm-workspace.yaml
+++ b/spirl-video-synth/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/spirl-video-synth/tests/api.test.ts
+++ b/spirl-video-synth/tests/api.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'child_process';
+
+describe('scan worker', () => {
+  it('produces scan.json from sample.mp4', async () => {
+    const p = spawn('python', ['workers/scan/spirl_scan.py', 'fixtures/sample.mp4'], { cwd: path.join(process.cwd(), 'spirl-video-synth') });
+    await new Promise((res, rej) => { p.on('close', c => c ? rej() : res(null)); });
+    const sj = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'spirl-video-synth', 'fixtures', 'scan.json'), 'utf-8'));
+    expect(sj.rails.length).toBeGreaterThanOrEqual(3);
+    expect(sj.apex_times.length).toBeGreaterThan(0);
+    expect(sj.alphas.length).toBe(3);
+  });
+});

--- a/spirl-video-synth/tests/scan.test.py
+++ b/spirl-video-synth/tests/scan.test.py
@@ -1,0 +1,13 @@
+import json, subprocess, os
+
+ROOT = os.path.join(os.path.dirname(__file__), '..')
+
+subprocess.run(['python', 'workers/scan/spirl_scan.py', 'fixtures/sample.mp4'], cwd=ROOT, check=True)
+with open(os.path.join(ROOT, 'fixtures', 'scan.json')) as f:
+    data = json.load(f)
+
+assert len(data['rails']) >= 3
+assert len(data['apex_times']) > 0
+assert len(data['alphas']) == 3
+
+print('ok')

--- a/spirl-video-synth/workers/scan/requirements.txt
+++ b/spirl-video-synth/workers/scan/requirements.txt
@@ -1,0 +1,3 @@
+opencv-python
+numpy
+scipy

--- a/spirl-video-synth/workers/scan/run_worker.py
+++ b/spirl-video-synth/workers/scan/run_worker.py
@@ -1,0 +1,25 @@
+# tiny HTTP worker (upload → scan.json)
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import cgi, os, json, subprocess
+
+PORT = int(os.environ.get("PORT", "8787"))
+ROOT = os.path.dirname(__file__)
+
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path != "/scan": self.send_error(404); return
+        ctype, pdict = cgi.parse_header(self.headers.get('content-type'))
+        if ctype != 'multipart/form-data': self.send_error(400); return
+        pdict['boundary'] = bytes(pdict['boundary'], "utf-8")
+        pdict['CONTENT-LENGTH'] = int(self.headers['content-length'])
+        form = cgi.parse_multipart(self.rfile, pdict)
+        video = form.get('file')[0]
+        fname = "upload.mp4"
+        with open(fname,"wb") as f: f.write(video)
+        subprocess.run(["python", "spirl_scan.py", fname], check=True)
+        with open("scan.json","rb") as f: data=f.read()
+        self.send_response(200); self.send_header("content-type","application/json"); self.end_headers()
+        self.wfile.write(data)
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b"OK")
+HTTPServer(("", PORT), H).serve_forever()

--- a/spirl-video-synth/workers/scan/spirl_scan.py
+++ b/spirl-video-synth/workers/scan/spirl_scan.py
@@ -1,0 +1,110 @@
+import cv2, json, numpy as np
+from scipy.optimize import least_squares
+import os, sys
+
+def phi_smooth(prev, curr, alpha=0.618):
+    return alpha*prev + (1-alpha)*curr
+
+def track(video_path, max_pts=400, step=2):
+    cap = cv2.VideoCapture(video_path)
+    ok, frame = cap.read(); assert ok, "cannot read video"
+    H, W = frame.shape[:2]
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    g0 = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    pts = cv2.goodFeaturesToTrack(g0, max_pts, 0.01, 8)
+    lk = dict(winSize=(21,21), maxLevel=3,
+              criteria=(cv2.TERM_CRITERIA_EPS|cv2.TERM_CRITERIA_COUNT, 30, 0.03))
+    tracks=[[] for _ in range(len(pts))]
+    prev=g0; pprev=pts; f=0; canny_prev=np.zeros_like(g0)
+    bands=[]
+    while True:
+        ok, frame = cap.read()
+        if not ok: break
+        if f % step != 0: f+=1; continue
+        g = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        pnext, st, _ = cv2.calcOpticalFlowPyrLK(prev, g, pprev, None, **lk)
+        if pnext is None: break
+        # φ-jostle edge map
+        edges = cv2.Canny(g, 60, 160)
+        dt = cv2.absdiff(edges, canny_prev)
+        theta = 0.04
+        edges_phi = phi_smooth(edges.astype(np.float32), dt.astype(np.float32), 0.618) + theta*dt
+        canny_prev = edges.copy()
+        # estimate dominant band angle
+        gx = cv2.Sobel(g, cv2.CV_32F,1,0,3); gy = cv2.Sobel(g, cv2.CV_32F,0,1,3)
+        ang = np.arctan2(gy, gx); bands.append(np.median(ang))
+        # save tracks
+        k=0
+        for i,(n,o) in enumerate(zip(pnext, pprev)):
+            if st[i]==1:
+                tracks[k].append((f, float(n[0][0]), float(n[0][1])))
+                k+=1
+        prev, pprev = g, pnext; f+=1
+    cap.release()
+    tracks = [t for t in tracks if len(t)>30]
+    return tracks, fps, (W,H), [float(np.median(bands))] if bands else [0.0]
+
+def cyl_fit(tr):
+    t = np.array([r[0] for r in tr], float); t = (t - t[0])/30.0
+    xs = np.array([r[1] for r in tr], float)
+    ys = np.array([r[2] for r in tr], float)
+    A = (ys.max()-ys.min())/2.0 + 1e-3
+    x0, y0 = xs.mean(), ys.min()
+    omega = 2*np.pi/(t[-1]-t[0]+1e-3)
+    p0 = np.array([A, omega, 0.2, x0, y0, 0.03, 1.2])
+    def model(p):
+        A,w,phi0,x0,y0,th,nu = p
+        phi = w*t + phi0 + th*np.sin(nu*t)
+        x = x0 + A*(phi - np.sin(phi))
+        y = y0 + A*(1 - np.cos(phi))
+        return np.hstack([x-xs, y-ys])
+    bnds = ([-np.inf,0,-np.pi,-np.inf,-np.inf,-0.2,0.2], [np.inf,10,np.pi,np.inf,np.inf,0.2,4.0])
+    res = least_squares(model, p0, bounds=bnds, max_nfev=3000)
+    err = float(np.linalg.norm(model(res.x))/len(t))
+    A,w,phi0,x0,y0,th,nu = res.x
+    return dict(A=float(A), omega=float(w), phi0=float(phi0), x0=float(x0), y0=float(y0),
+                theta_prime=float(th), nu=float(nu), err=err)
+
+def apex(params, t0=0, t1=5.0, step=0.02):
+    def xy(p,t):
+        A,w,phi0,x0,y0,th,nu = p
+        phi = w*t + phi0 + th*np.sin(nu*t)
+        x = x0 + A*(phi - np.sin(phi))
+        y = y0 + A*(1 - np.cos(phi))
+        return x,y
+    P = [np.array([p['A'],p['omega'],p['phi0'],p['x0'],p['y0'],p['theta_prime'],p['nu']], float) for p in params]
+    out=[]
+    for k in np.arange(t0,t1,step):
+        pts=[]
+        for p in P[:3]:
+            x,y = xy(p,k); pts.append((x,y))
+        d12 = np.hypot(pts[0][0]-pts[1][0], pts[0][1]-pts[1][1])
+        d23 = np.hypot(pts[1][0]-pts[2][0], pts[1][1]-pts[2][1])
+        d31 = np.hypot(pts[2][0]-pts[0][0], pts[2][1]-pts[0][1])
+        if d12<4 and d23<4 and d31<4:
+            if not out or abs(k-out[-1])>0.2: out.append(float(k))
+    return out
+
+def main(video):
+    tracks,fps,(W,H),ang = track(video)
+    tracks = sorted(tracks, key=len, reverse=True)[:12]
+    fits = [cyl_fit(tr) for tr in tracks]
+    fits = sorted(fits, key=lambda r: r["err"])[:6]
+    if len(ang)==1:
+        a = ang[0]; alphas=[a, (a+2*np.pi/3)%(2*np.pi), (a+4*np.pi/3)%(2*np.pi)]
+    else: alphas=ang[:3]
+    cad = {"in":0.541,"out":0.459,"gap":0.082,"half_gap":0.041}
+    apexes = apex(fits, 0, len(tracks[0])/fps)
+    scan = {
+        "meta": {"fps": fps, "width": W, "height": H, "video": os.path.basename(video)},
+        "cadence": cad,
+        "alphas": alphas,
+        "rails": fits,
+        "apex_times": apexes
+    }
+    out = os.path.join(os.path.dirname(video) or ".", "scan.json")
+    with open(out,"w") as f: json.dump(scan, f, indent=2)
+    print("wrote", out)
+
+if __name__=="__main__":
+    main(sys.argv[1] if len(sys.argv)>1 else "fixtures/sample.mp4")


### PR DESCRIPTION
## Summary
- scaffold `spirl-video-synth` monorepo with web app, API, viewer, core types and Python scan worker
- include fixtures and basic tests exercising worker output

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `python tests/scan.test.py` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68afe1545e508327a649af95edb06ac5