### PR TITLE
Add Vitest suite for portal module

### DIFF
--- a/packages/core/portal/package.json
+++ b/packages/core/portal/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "spirl-portal",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/core/portal/portal.ts
+++ b/packages/core/portal/portal.ts
@@ -1,0 +1,85 @@
+export const Consts = {
+  zeta3Approx: 1.202056903159594
+};
+
+export function primesUpTo(limit: number): number[] {
+  if (limit < 2) return [];
+  const sieve = new Array(limit + 1).fill(true);
+  sieve[0] = sieve[1] = false;
+  for (let p = 2; p * p <= limit; p++) {
+    if (sieve[p]) {
+      for (let i = p * p; i <= limit; i += p) sieve[i] = false;
+    }
+  }
+  const primes: number[] = [];
+  for (let i = 2; i <= limit; i++) if (sieve[i]) primes.push(i);
+  return primes;
+}
+
+export function nthPrime(n: number): number {
+  if (n < 1) throw new Error("n must be >=1");
+  let limit = 15;
+  while (primesUpTo(limit).length < n) limit *= 2;
+  return primesUpTo(limit)[n - 1];
+}
+
+export function partialZeta3ByIndex(n: number): number {
+  let s = 0;
+  for (let k = 1; k <= n; k++) s += 1 / (k * k * k);
+  return s;
+}
+
+export function chiQ(n: number): number {
+  return n % 2 === 0 ? 1 : -1;
+}
+
+export function shadowToothSign(t: number): number {
+  const period = 0.55 * 3 + 0.45 * 3; // 3
+  const m = ((t % period) + period) % period;
+  return m < 0.55 * 3 ? 1 : -1;
+}
+
+export function P_of(n: number): number {
+  return chiQ(n) * nthPrime(n);
+}
+
+function normalize(v: [number, number, number]): [number, number, number] {
+  const len = Math.hypot(v[0], v[1], v[2]);
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+export function witnessLiftSO4(axis: [number, number, number], angle: number, chi: number) {
+  const [x, y, z] = normalize(axis);
+  const c = Math.cos(angle);
+  const s = Math.sin(angle) * chi;
+  const t = 1 - c;
+  const R3 = [
+    t * x * x + c,
+    t * x * y - s * z,
+    t * x * z + s * y,
+    t * y * x + s * z,
+    t * y * y + c,
+    t * y * z - s * x,
+    t * z * x - s * y,
+    t * z * y + s * x,
+    t * z * z + c
+  ];
+  const R4 = [
+    R3[0], R3[1], R3[2], 0,
+    R3[3], R3[4], R3[5], 0,
+    R3[6], R3[7], R3[8], 0,
+    0, 0, 0, 1
+  ];
+  return { R4 };
+}
+
+export function portalFunctional(n: number, t: number, opts?: { thetaPrime?: number; usePortalInZoom?: boolean }) {
+  const Pn = P_of(n);
+  const zetaTerm = partialZeta3ByIndex(n);
+  const thetaPrime = opts?.thetaPrime ?? 0;
+  const s = Math.sin(t + thetaPrime);
+  const alpha = Math.cos(t);
+  const h = Pn * alpha;
+  const d = shadowToothSign(t);
+  return { s, alpha, h, Pn, zetaTerm, d };
+}

--- a/packages/core/portal/test/portal.test.ts
+++ b/packages/core/portal/test/portal.test.ts
@@ -1,0 +1,75 @@
+import {
+  nthPrime, partialZeta3ByIndex, primesUpTo,
+  chiQ, shadowToothSign, P_of,
+  witnessLiftSO4, portalFunctional, Consts
+} from "../portal";
+
+// helpers
+const approx = (a: number, b: number, tol=1e-9) => Math.abs(a - b) <= tol;
+function matT(A: number[]): number[] { const T=new Array(16); for(let r=0;r<4;r++)for(let c=0;c<4;c++)T[4*r+c]=A[4*c+r]; return T; }
+function matMul(A: number[], B: number[]): number[]{const C=new Array(16).fill(0);for(let r=0;r<4;r++)for(let c=0;c<4;c++)for(let k=0;k<4;k++)C[4*r+c]+=A[4*r+k]*B[4*k+c];return C;}
+function isIdentity(A: number[], tol=1e-8): boolean {for(let r=0;r<4;r++)for(let c=0;c<4;c++){const want=(r===c)?1:0;if(Math.abs(A[4*r+c]-want)>tol)return false;}return true;}
+
+// tests
+describe("prime utilities", () => {
+  it("nthPrime matches first 16 primes", () => {
+    const table=[2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53];
+    for(let i=1;i<=table.length;i++) expect(nthPrime(i)).toBe(table[i-1]);
+  });
+  it("primesUpTo returns primes up to limit", () => {
+    expect(primesUpTo(30)).toEqual([2,3,5,7,11,13,17,19,23,29]);
+  });
+});
+
+describe("partial ζ(3) product", () => {
+  it("is monotone increasing", () => {
+    const vals=[5,10,20,30].map(n=>partialZeta3ByIndex(n));
+    for(let i=1;i<vals.length;i++) expect(vals[i]).toBeGreaterThan(vals[i-1]);
+  });
+  it("approaches Apéry’s constant loosely", () => {
+    const z50=partialZeta3ByIndex(50);
+    expect(Math.abs(z50-Consts.zeta3Approx)).toBeLessThan(0.06);
+  });
+});
+
+describe("chirality & cadence", () => {
+  it("chiQ alternates ±1", () => {
+    expect(chiQ(1)).toBe(-1); expect(chiQ(2)).toBe(1);
+  });
+  it("shadowToothSign 0.55×3 then 0.45×3", () => {
+    const blocks=[0.55,0.55,0.55,0.45,0.45,0.45]; const T=blocks.reduce((a,b)=>a+b,0);
+    let t=0; for(let i=0;i<blocks.length;i++){const mid=t+blocks[i]/2;const s=shadowToothSign(mid); if(i<3) expect(s).toBe(1); else expect(s).toBe(-1); t+=blocks[i];}
+    expect(shadowToothSign(T+0.1)).toBe(1);
+  });
+});
+
+describe("portal constant P(n)", () => {
+  it("finite values & chiQ flip", () => {
+    const p5=P_of(5), p6=P_of(6), p50=P_of(50);
+    expect(Number.isFinite(p5)).toBe(true); expect(Number.isFinite(p50)).toBe(true);
+    expect(p5).not.toBe(p6);
+  });
+});
+
+describe("witness lift SO(4)", () => {
+  it("R4 orthogonal: RᵀR≈I", () => {
+    const {R4}=witnessLiftSO4([0,1,0],Math.PI/3,1); const RTR=matMul(matT(R4),R4);
+    expect(isIdentity(RTR,1e-8)).toBe(true);
+  });
+  it("chirality flips skew", () => {
+    const {R4:A}=witnessLiftSO4([0,1,0],1.234,1);
+    const {R4:B}=witnessLiftSO4([0,1,0],1.234,-1);
+    let diff=0; for(let i=0;i<16;i++) diff+=Math.abs(A[i]-B[i]); expect(diff).toBeGreaterThan(1e-6);
+  });
+});
+
+describe("portal functional driver", () => {
+  it("finite fields & cadence flips", () => {
+    const S0=portalFunctional(7,0.2,{thetaPrime:0.25,usePortalInZoom:true});
+    for(const k of ["s","alpha","h","Pn","zetaTerm"] as const)
+      expect(Number.isFinite((S0 as any)[k])).toBe(true);
+    const d0=portalFunctional(7,0.2).d, d1=portalFunctional(7,1.8).d, d2=portalFunctional(7,3.6).d;
+    expect(d0).toBe(1); expect(d1).toBe(-1); expect(d2).toBe(1);
+  });
+});
+

--- a/packages/core/portal/tsconfig.json
+++ b/packages/core/portal/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/core/portal/vitest.config.ts
+++ b/packages/core/portal/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    globals: true,
+    reporters: ["default"],
+    watch: false
+  }
+});


### PR DESCRIPTION
## Summary
- add SP1RL portal module with prime helpers, witness lift, and portal functional
- configure Vitest + TypeScript harness and tests for portal behaviours

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*

------
https://chatgpt.com/codex/tasks/task_e_68b18ee4866c8327b8d0f2c95bace7cb