### PR TITLE
feat: add Sky-Opera storyboard tooling

### DIFF
--- a/spirl-storyboard/README.md
+++ b/spirl-storyboard/README.md
@@ -1,0 +1,21 @@
+# spirl-storyboard
+
+Minimal tools for TeLL’aLL Sky‑Opera storyboards.  It parses a YAML file,
+validates structure, expands cues with heuristic ZCM scores, and can render a
+bare‑bones HTML preview.
+
+## Development
+
+```bash
+npm install --no-package-lock
+npm run build
+npm test
+```
+
+## CLI
+
+```bash
+node dist/index.js lint examples/penguin_mug.yml
+node dist/index.js expand examples/penguin_mug.yml out.json
+node dist/index.js html examples/penguin_mug.yml out.html
+```

--- a/spirl-storyboard/examples/penguin_mug.yml
+++ b/spirl-storyboard/examples/penguin_mug.yml
@@ -1,0 +1,44 @@
+meta:
+  id: "spq-2025-08-29"
+  title: "Penguin Mug"
+  episode: "S1E12"
+  date: "2025-08-29"
+  cast: [ "Kap", "Greg", "Dewey", "Sophia", ".Q" ]
+
+cues:
+  - cue: SCROLL_OPEN
+    vo: "You only see the shadows…"
+    bg: "phi-splatter"
+
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - { by: viewer, text: "It’s a regular coffee mug." }
+      - { by: viewer, text: "Nope, definitely a penguin." }
+      - { by: greg,   text: "Let me find out!!" }
+    riff: "Kill Tony–style minute on mugs vs birds"
+
+  - cue: TRAINING
+    track: "Dewey sax riff"
+    morphs: [ "2D silhouette", "inflate", "spin", "bridge handle→beak" ]
+    interject: [ "Greg: 'never drink out of a beak'" ]
+
+  - cue: REVEAL
+    forms: [ "Mug", "Handle", "Penguin-bridge" ]
+    bridge: "handle aligns with beak at α"
+    typewriter:
+      - "Ledger: PENGUIN_MUG"
+      - "Witness: .Q"
+
+  - cue: LEDGER_CHECK
+    ledger: { entry: "PENGUIN_MUG", witness: ".Q" }
+
+  - cue: NFT_RAIN
+    sparkle: "top rafters"
+    badges:
+      - { name: "MugLife",   desc: "cozy story vibe", zcm_hint: "story ambience cozy" }
+      - { name: "BirdBrain", desc: "penguin pun",     zcm_hint: "sarcasm lol" }
+
+  - cue: OUTRO
+    cta: "Congrats @username! Drop your guess for tomorrow, and Greg will let-me-find-out again."
+    confetti: true

--- a/spirl-storyboard/examples/weekly_teallan.yml
+++ b/spirl-storyboard/examples/weekly_teallan.yml
@@ -1,0 +1,40 @@
+meta:
+  id: "teallan-2025-w35"
+  title: "KaP’t1N’s Quilt of 89²"
+  episode: "W35"
+  date: "2025-09-01"
+  cast: [ "Kap", "Greg", "Dewey", "Sophia", ".Q" ]
+
+cues:
+  - cue: SCROLL_OPEN
+    vo: "Silence. Or I roll the scroll shut."
+    bg: "sky-canvas"
+
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - { by: viewer, text: "Is that a tear or a flame?" }
+      - { by: viewer, text: "I see the 5+5+3 penguin bike wheels!" }
+      - { by: greg,   text: "Let me find out!!" }
+
+  - cue: TRAINING
+    track: "Bloom + floss"
+    morphs: [ "petal wrap", "floss spiral", "crystallize 89²", "quilt fold" ]
+
+  - cue: REVEAL
+    forms: [ "Diamond Square A", "Diamond Square B", "Bandana 4×2 bridge" ]
+    typewriter:
+      - "Ledger: 89² bundle minted"
+      - "Witness: .Q; ZCM badges updated"
+
+  - cue: LEDGER_CHECK
+    ledger: { entry: "W35_DIAMOND_BUNDLE", witness: ".Q" }
+
+  - cue: NFT_RAIN
+    sparkle: "rafters"
+    badges:
+      - { name: "TeaL.N.g Drop", desc: "story-care mint", zcm_hint: "story clarity empathy" }
+      - { name: "K Courage",     desc: "tool builder",    zcm_hint: "math action" }
+
+  - cue: OUTRO
+    cta: "All P’LoTs: play the new quest squares. Your memes = badges. Your tools = K. See you next TeLL’aLL."

--- a/spirl-storyboard/package.json
+++ b/spirl-storyboard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spirl-storyboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "node ./dist/index.js lint examples/*.yml",
+    "build": "tsc -p .",
+    "test": "vitest run",
+    "dev": "vitest"
+  },
+  "devDependencies": {
+    "js-yaml": "^4.1.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/spirl-storyboard/src/cues.ts
+++ b/spirl-storyboard/src/cues.ts
@@ -1,0 +1,68 @@
+import type { Storyboard, CueName } from "./schema";
+import { zcmFromText, zcmScore } from "./zcm";
+
+export type TimelineEvent = {
+  t: number;                   // time offset (sec) - naive linear for now
+  cue: CueName;
+  data: any;
+};
+
+export function expand(board: Storyboard): { timeline: TimelineEvent[], receipts: any[] } {
+  const timeline: TimelineEvent[] = [];
+  const receipts: any[] = [];
+  let t = 0;
+
+  for (const c of board.cues) {
+    switch (c.cue) {
+      case "SCROLL_OPEN": {
+        timeline.push({ t, cue: "SCROLL_OPEN", data: c });
+        t += 3.5;
+        break;
+      }
+      case "COMMENTS_HOST": {
+        // compute per-comment ZCM & sass
+        const lines = c.comments.map((m, i) => {
+          const z = zcmFromText(m.text);
+          return { ...m, zcm: z, zcmScore: +zcmScore(z).toFixed(3), idx: i };
+        });
+        timeline.push({ t, cue: "COMMENTS_HOST", data: { ...c, lines } });
+        t += 6 + lines.length * 2;
+        break;
+      }
+      case "TRAINING": {
+        timeline.push({ t, cue: "TRAINING", data: c });
+        t += 7;
+        break;
+      }
+      case "REVEAL": {
+        timeline.push({ t, cue: "REVEAL", data: c });
+        t += 4;
+        break;
+      }
+      case "LEDGER_CHECK": {
+        // ledger “receipt”
+        receipts.push({ ts: Date.now(), entry: c.ledger.entry, witness: c.ledger.witness });
+        timeline.push({ t, cue: "LEDGER_CHECK", data: c });
+        t += 2.5;
+        break;
+      }
+      case "NFT_RAIN": {
+        // compute badge previews from zcm_hint
+        const drops = c.badges.map(b => {
+          const z = zcmFromText(b.zcm_hint || b.desc || b.name);
+          return { ...b, zcm: z, zcmScore: +zcmScore(z).toFixed(3) };
+        });
+        timeline.push({ t, cue: "NFT_RAIN", data: { ...c, drops } });
+        receipts.push({ ts: Date.now(), nft_rain: drops });
+        t += 3 + drops.length * 1.2;
+        break;
+      }
+      case "OUTRO": {
+        timeline.push({ t, cue: "OUTRO", data: c });
+        t += 2.5;
+        break;
+      }
+    }
+  }
+  return { timeline, receipts };
+}

--- a/spirl-storyboard/src/index.ts
+++ b/spirl-storyboard/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { parseYaml } from "./schema";
+import { expand } from "./cues";
+import { renderHTML } from "./render";
+
+function usage(){ console.log("usage: node dist/index.js <lint|expand|html> <file.yml> [out.json|out.html]"); }
+
+async function main(){
+  const [,,cmd, file, out] = process.argv;
+  if (!cmd || !file) return usage();
+  const yml = fs.readFileSync(file, "utf-8");
+  const board = parseYaml(yml);
+  if (cmd==="lint"){ console.log("OK:", board.meta.title); return; }
+  const { timeline, receipts } = expand(board);
+  if (cmd==="expand"){
+    const json = JSON.stringify({ meta: board.meta, timeline, receipts }, null, 2);
+    if (out) fs.writeFileSync(out, json); else console.log(json);
+    return;
+  }
+  if (cmd==="html"){
+    const html = renderHTML(board.meta.title, timeline);
+    if (out) fs.writeFileSync(out, html); else console.log(html);
+    return;
+  }
+  usage();
+}
+main().catch(e=>{ console.error(e); process.exit(1); });

--- a/spirl-storyboard/src/render.ts
+++ b/spirl-storyboard/src/render.ts
@@ -1,0 +1,14 @@
+// extremely small HTML generator for preview (no CSS/assets)
+import { TimelineEvent } from "./cues";
+
+export function renderHTML(title: string, timeline: TimelineEvent[]): string {
+  const rows = timeline.map(ev => {
+    const json = escapeHtml(JSON.stringify(ev.data));
+    return `<div><b>[${ev.t.toFixed(1)}s]</b> <code>${ev.cue}</code><pre>${json}</pre></div>`;
+  }).join("\n");
+  return `<!doctype html><meta charset="utf-8"><title>${escapeHtml(title)}</title>
+  <style>body{font:14px/1.4 system-ui;background:#0b1220;color:#e6efff;padding:16px}
+  pre{background:#101a2c;border:1px solid #13203a;border-radius:8px;padding:8px;white-space:pre-wrap}</style>
+  <h1>${escapeHtml(title)}</h1>${rows}`;
+}
+function escapeHtml(s: string){ return s.replace(/[&<>]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]!)); }

--- a/spirl-storyboard/src/schema.ts
+++ b/spirl-storyboard/src/schema.ts
@@ -1,0 +1,40 @@
+import yaml from "js-yaml";
+
+export type CueName =
+  | "SCROLL_OPEN" | "COMMENTS_HOST" | "TRAINING" | "REVEAL"
+  | "LEDGER_CHECK" | "NFT_RAIN" | "OUTRO";
+
+export type CommentLine = { by: "greg"|"viewer"|"npc"; text: string };
+
+export interface Storyboard {
+  meta: {
+    id: string; title: string; episode: string; date: string;
+    cast: string[]; // ["Kap","Greg","Dewey","Sophia",".Q"]
+  };
+  cues: Array<
+    | { cue: "SCROLL_OPEN"; vo: string; bg?: string }
+    | { cue: "COMMENTS_HOST"; host: "Greg"; comments: CommentLine[]; riff?: string }
+    | { cue: "TRAINING"; track: string; morphs: string[]; interject?: string[] }
+    | { cue: "REVEAL"; forms: string[]; bridge?: string; typewriter: string[] }
+    | { cue: "LEDGER_CHECK"; ledger: { entry: string; witness: string } }
+    | { cue: "NFT_RAIN"; badges: Array<{name:string; desc:string; zcm_hint?:string}>; sparkle?: string }
+    | { cue: "OUTRO"; cta: string; confetti?: boolean }
+  >;
+}
+
+export function parseYaml(yml: string): Storyboard {
+  const obj = yaml.load(yml) as any;
+  // minimal structural checks
+  if (!obj?.meta?.id || !obj?.meta?.title || !Array.isArray(obj?.cues)) {
+    throw new Error("Invalid storyboard: missing meta.id/meta.title/cues[]");
+  }
+  // Validate cue entries
+  for (const c of obj.cues) {
+    if (!c?.cue) throw new Error("Cue missing 'cue' field");
+    const name = c.cue as CueName;
+    if (!["SCROLL_OPEN","COMMENTS_HOST","TRAINING","REVEAL","LEDGER_CHECK","NFT_RAIN","OUTRO"].includes(name)) {
+      throw new Error(`Unknown cue: ${name}`);
+    }
+  }
+  return obj as Storyboard;
+}

--- a/spirl-storyboard/src/zcm.ts
+++ b/spirl-storyboard/src/zcm.ts
@@ -1,0 +1,25 @@
+export type ZcmVec = Record<"sarcasm"|"clarity"|"empathy"|"story"|"math"|"action"|"ambience"|"color"|"rhythm", number>;
+export const ZCM_AXES: (keyof ZcmVec)[] = ["sarcasm","clarity","empathy","story","math","action","ambience","color","rhythm"];
+
+export function zeros(): ZcmVec { return Object.fromEntries(ZCM_AXES.map(k=>[k,0])) as ZcmVec; }
+
+export function zcmFromText(text: string): ZcmVec {
+  const v = zeros(); const t = text || "";
+  const rx = (p: RegExp) => p.test(t);
+  if (rx(/lol|yeah right|sure|obviously|goo theorem|no-ether|!{2,}|\?{2,}/i)) v.sarcasm = 0.6;
+  if (rx(/( is | means | define | proof | therefore )/i)) v.clarity = Math.max(v.clarity, 0.6);
+  if (rx(/sorry|help|care|empathy|gentle/i)) v.empathy = 0.6;
+  if (rx(/quest|lore|dialog|cutscene|story/i)) v.story = 0.6;
+  if (rx(/phi|theta|ratio|euler|cycloid|venturi|math/i)) v.math = 0.7;
+  if (rx(/attack|dash|jump|run|dodge/i)) v.action = 0.6;
+  if (rx(/rain|wind|fog|ambience|reverb/i)) v.ambience = 0.6;
+  if (rx(/violet|gold|blue|red|palette|hue/i)) v.color = 0.6;
+  if (rx(/beat|tempo|meter|rhythm|drum/i)) v.rhythm = 0.6;
+  if (/\?/.test(t)) v.clarity = Math.max(v.clarity, 0.3);
+  return v;
+}
+
+export function zcmScore(v: ZcmVec): number {
+  // Weighted sass-fit score for badge/NFT ranking
+  return 0.25*v.sarcasm + 0.2*v.story + 0.2*v.clarity + 0.15*v.math + 0.2*(v.action+v.rhythm)/2;
+}

--- a/spirl-storyboard/test/cues.test.ts
+++ b/spirl-storyboard/test/cues.test.ts
@@ -1,0 +1,39 @@
+import { parseYaml } from "../src/schema";
+import { expand } from "../src/cues";
+
+const Y = `
+meta: { id: "ep-001", title: "Penguin Mug", episode: "S1E12", date: "2025-08-29", cast: [".Q","Greg","Kap","Dewey","Sophia"] }
+cues:
+  - cue: SCROLL_OPEN
+    vo: "You only see the shadows…"
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - {by: viewer, text: "It’s a mug"}
+      - {by: viewer, text: "No, it’s the penguin!!"}
+      - {by: greg,   text: "Let me find out!!"}
+  - cue: TRAINING
+    track: "Dewey riff"
+    morphs: ["2D outline","inflate","spin"]
+  - cue: REVEAL
+    forms: ["Mug","Handle","Penguin-bridge"]
+    typewriter: ["Ledger: PENGUIN_MUG", "Apéry witness .Q"]
+  - cue: LEDGER_CHECK
+    ledger: { entry: "PENGUIN_MUG", witness: ".Q" }
+  - cue: NFT_RAIN
+    badges:
+      - {name: "MugLife", desc: "coffee lovers", zcm_hint: "story cozy"}
+      - {name: "BirdBrain", desc: "penguin pun", zcm_hint: "sarcasm lol"}
+  - cue: OUTRO
+    cta: "Drop your guess for tomorrow!"
+`;
+
+describe("expand", () => {
+  it("produces a timeline with receipts", () => {
+    const b = parseYaml(Y);
+    const { timeline, receipts } = expand(b);
+    expect(timeline.length).toBeGreaterThan(3);
+    expect(receipts.find(r=>r.entry==="PENGUIN_MUG")).toBeTruthy();
+    expect(timeline.some(ev => ev.cue==="NFT_RAIN")).toBe(true);
+  });
+});

--- a/spirl-storyboard/test/schema.test.ts
+++ b/spirl-storyboard/test/schema.test.ts
@@ -1,0 +1,26 @@
+import { parseYaml } from "../src/schema";
+
+const Y = `
+meta:
+  id: "ep-001"
+  title: "Penguin Mug"
+  episode: "S1E12"
+  date: "2025-08-29"
+  cast: ["Kap","Greg","Dewey","Sophia",".Q"]
+cues:
+  - cue: SCROLL_OPEN
+    vo: "You only see the shadows…"
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - {by: viewer, text: "It’s clearly a coffee mug."}
+      - {by: greg,   text: "Let me find out!!"}
+`;
+
+describe("schema", () => {
+  it("parses minimal YAML", () => {
+    const b = parseYaml(Y);
+    expect(b.meta.title).toBe("Penguin Mug");
+    expect(b.cues.length).toBeGreaterThan(0);
+  });
+});

--- a/spirl-storyboard/test/zcm.test.ts
+++ b/spirl-storyboard/test/zcm.test.ts
@@ -1,0 +1,11 @@
+import { zcmFromText, zcmScore } from "../src/zcm";
+
+describe("ZCM", () => {
+  it("detects sarcasm/clarity", () => {
+    const a = zcmFromText("lol obviously!! define the ratio");
+    expect(a.sarcasm).toBeGreaterThan(0);
+    expect(a.clarity).toBeGreaterThan(0);
+    const s = zcmScore(a);
+    expect(s).toBeGreaterThan(0.1);
+  });
+});

--- a/spirl-storyboard/tsconfig.json
+++ b/spirl-storyboard/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "dist",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/spirl-storyboard/vitest.config.ts
+++ b/spirl-storyboard/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: { include: ["test/**/*.test.ts"], globals: true, watch: false }
+});


### PR DESCRIPTION
## Summary
- add standalone `spirl-storyboard` package for YAML-driven Sky-Opera storyboards
- implement cue expansion with ZCM badge scoring and minimal HTML preview
- include sample episodes, TypeScript schema, and Vitest coverage

## Testing
- `npm install --no-package-lock --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/js-yaml)*
- `npm run build` *(fails: Cannot find type definition file for 'vitest/globals')*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `node dist/index.js lint examples/penguin_mug.yml` *(fails: Cannot find module '.../dist/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b1fc1a1e20832797585ec985d4b450