### PR TITLE
feat: add storyboard ledger and continuity modules

### DIFF
--- a/spirl-storyboard/examples/penguin_mug.yml
+++ b/spirl-storyboard/examples/penguin_mug.yml
@@ -8,24 +8,21 @@ meta:
 cues:
   - cue: SCROLL_OPEN
     vo: "You only see the shadows…"
-    bg: "phi-splatter"
 
   - cue: COMMENTS_HOST
     host: "Greg"
     comments:
-      - { by: viewer, text: "It’s a regular coffee mug." }
-      - { by: viewer, text: "Nope, definitely a penguin." }
-      - { by: greg,   text: "Let me find out!!" }
-    riff: "Kill Tony–style minute on mugs vs birds"
+      - { by: viewer, user: "@ness", text: "It’s a coffee mug!" }
+      - { by: viewer, user: "@dot",  text: "That’s the penguin silhouette." }
+      - { by: greg,                 text: "Let me find out!!" }
 
-  - cue: TRAINING
-    track: "Dewey sax riff"
-    morphs: [ "2D silhouette", "inflate", "spin", "bridge handle→beak" ]
-    interject: [ "Greg: 'never drink out of a beak'" ]
+  - cue: MORPH_TRAINING
+    dewey_track: "SP1RL_Saxophone"
+    sophia_track: "A-BLOOM_Line"
+    sequence: [ "dot→line", "line→square", "square→diamond", "diamond→circle" ]
 
   - cue: REVEAL
     forms: [ "Mug", "Handle", "Penguin-bridge" ]
-    bridge: "handle aligns with beak at α"
     typewriter:
       - "Ledger: PENGUIN_MUG"
       - "Witness: .Q"
@@ -34,11 +31,21 @@ cues:
     ledger: { entry: "PENGUIN_MUG", witness: ".Q" }
 
   - cue: NFT_RAIN
-    sparkle: "top rafters"
+    sparkle: "rafters"
     badges:
       - { name: "MugLife",   desc: "cozy story vibe", zcm_hint: "story ambience cozy" }
       - { name: "BirdBrain", desc: "penguin pun",     zcm_hint: "sarcasm lol" }
 
+  - cue: SFX
+    names: [ "BELL_TOLL", "SEAGULLS", "FOG_HORN", "CLAP", "CONFETTI_POP", "LAUGH" ]
+
+  - cue: GUESS_PREVIEW
+    teaser:
+      silhouette: "blob-crown-left, two circles bottom, tear-oval"
+      hint: "mug-handle"
+      tease_id: "tease-001"
+
   - cue: OUTRO
-    cta: "Congrats @username! Drop your guess for tomorrow, and Greg will let-me-find-out again."
+    cta: "Don’t forget to like & subscribe, matey!"
     confetti: true
+

--- a/spirl-storyboard/examples/penguin_mug_next.yml
+++ b/spirl-storyboard/examples/penguin_mug_next.yml
@@ -1,0 +1,50 @@
+meta:
+  id: "spq-2025-08-30"
+  title: "Next Mystery"
+  episode: "S1E13"
+  date: "2025-08-30"
+  prev_id: "spq-2025-08-29"
+  cast: [ "Kap", "Greg", "Dewey", "Sophia", ".Q" ]
+
+cues:
+  - cue: SCROLL_OPEN
+    vo: "Silence. Or I roll the scroll shut."
+    bg: "sky-canvas"
+
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - { by: viewer, user: "@ness", text: "I said mug and penguin!!" }
+      - { by: viewer, user: "@dot",  text: "It was obviously the handle-beak bridge." }
+      - { by: greg,                 text: "Let me find out… again!!" }
+
+  - cue: AWARD_MFT
+    winner: { user: "@ness", guess: "coffee mug", award: "MFT Golden Badge" }
+
+  - cue: MORPH_TRAINING
+    dewey_track: "SP1RL_Saxophone"
+    sophia_track: "A-BLOOM_Line"
+    sequence: [ "dot→line", "line→square", "square→diamond", "diamond→circle" ]
+
+  - cue: REVEAL
+    forms: [ "Mystery_A", "Mystery_B", "bridge" ]
+    typewriter: [ "Ledger: NEXT_MYSTERY", "Witness: .Q" ]
+
+  - cue: LEDGER_CHECK
+    ledger: { entry: "NEXT_MYSTERY", witness: ".Q" }
+
+  - cue: NFT_RAIN
+    badges:
+      - { name: "TeaL Drop",   desc: "story-care", zcm_hint: "story empathy" }
+      - { name: "K Courage",   desc: "tool-builder", zcm_hint: "math action" }
+
+  - cue: SFX
+    names: [ "BELL_TOLL", "SEAGULLS", "FOG_HORN", "CLAP", "CONFETTI_POP", "LAUGH" ]
+
+  - cue: GUESS_PREVIEW
+    teaser: { silhouette: "looks nothing like it", hint: "??", tease_id: "tease-002" }
+
+  - cue: OUTRO
+    cta: "Drop your guesses in the comments for a chance to win!"
+    confetti: true
+

--- a/spirl-storyboard/src/continuity.ts
+++ b/spirl-storyboard/src/continuity.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+
+export type Teaser = { meta_id: string; title: string; silhouette: string; hint: string; tease_id: string };
+
+/** Build next-episode YAML scaffold that:
+ *  - starts with COMMENTS_HOST to read previous guesses
+ *  - includes AWARD_MFT placeholder
+ *  - includes a new GUESS_PREVIEW ("looks-nothing-like" silhouette stub)
+ */
+export function buildNextEpisodeYaml(prev: Teaser, nextMeta: { id:string; title:string; episode:string; date:string; cast:string[] }): string {
+  const teaserHint = obfuscate(prev.hint);
+  return `meta:
+  id: "${nextMeta.id}"
+  title: "${nextMeta.title}"
+  episode: "${nextMeta.episode}"
+  date: "${nextMeta.date}"
+  prev_id: "${prev.meta_id}"
+  cast: [ ${nextMeta.cast.map(q=>JSON.stringify(q)).join(", ")} ]
+
+cues:
+  - cue: SCROLL_OPEN
+    vo: "Silence. Or I roll the scroll shut."
+    bg: "sky-canvas"
+
+  - cue: COMMENTS_HOST
+    host: "Greg"
+    comments:
+      - { by: viewer, user: "@winner", text: "…" }
+      - { by: greg,   text: "Let me find out!!" }
+
+  - cue: MORPH_TRAINING
+    dewey_track: "SP1RL_Saxophone"
+    sophia_track: "A-BLOOM_Line"
+    sequence: [ "dot→line", "line→square", "square→diamond", "diamond→circle" ]
+
+  - cue: REVEAL
+    forms: [ "${prev.title}_A", "${prev.title}_B", "bridge" ]
+    typewriter: [ "Ledger: ${prev.title.toUpperCase()}_REVEAL", "Witness: .Q" ]
+
+  - cue: LEDGER_CHECK
+    ledger: { entry: "${prev.title.toUpperCase()}_REVEAL", witness: ".Q" }
+
+  - cue: AWARD_MFT
+    winner: { user: "@winner", guess: "…", award: "MFT Golden Badge" }
+
+  - cue: NFT_RAIN
+    sparkle: "rafters"
+    badges:
+      - { name: "TeaL Drop",   desc: "story-care", zcm_hint: "story empathy" }
+      - { name: "K Courage",   desc: "tool-builder", zcm_hint: "math action" }
+
+  - cue: SFX
+    names: [ "BELL_TOLL", "SEAGULLS", "FOG_HORN", "CLAP", "CONFETTI_POP", "LAUGH" ]
+
+  - cue: GUESS_PREVIEW
+    teaser: { silhouette: "${teaserHint}", hint: "looks nothing like it", tease_id: "${prev.tease_id}-NXT" }
+
+  - cue: OUTRO
+    cta: "Don’t forget to like and subscribe, matey!"
+    confetti: true
+`;
+}
+
+function obfuscate(s: string): string {
+  // crude “looks-nothing-like” obfuscation by scrambling tokens
+  return s.split("").sort(()=>Math.random()-0.5).join("");
+}
+

--- a/spirl-storyboard/src/cues.ts
+++ b/spirl-storyboard/src/cues.ts
@@ -1,68 +1,77 @@
 import type { Storyboard, CueName } from "./schema";
 import { zcmFromText, zcmScore } from "./zcm";
+import { writeAutoReceipts } from "./ledger";
+import { resolveSfx } from "./sfx";
 
-export type TimelineEvent = {
-  t: number;                   // time offset (sec) - naive linear for now
-  cue: CueName;
-  data: any;
-};
+export type TimelineEvent = { t: number; cue: CueName; data: any };
 
 export function expand(board: Storyboard): { timeline: TimelineEvent[], receipts: any[] } {
   const timeline: TimelineEvent[] = [];
   const receipts: any[] = [];
   let t = 0;
 
+  const push = (cue: CueName, data: any, dur: number, receipt?: any) => {
+    timeline.push({ t, cue, data }); t += dur;
+    if (receipt) receipts.push(receipt);
+  };
+
   for (const c of board.cues) {
     switch (c.cue) {
       case "SCROLL_OPEN": {
-        timeline.push({ t, cue: "SCROLL_OPEN", data: c });
-        t += 3.5;
-        break;
+        push("SCROLL_OPEN", c, 3.5); break;
       }
       case "COMMENTS_HOST": {
-        // compute per-comment ZCM & sass
         const lines = c.comments.map((m, i) => {
           const z = zcmFromText(m.text);
           return { ...m, zcm: z, zcmScore: +zcmScore(z).toFixed(3), idx: i };
         });
-        timeline.push({ t, cue: "COMMENTS_HOST", data: { ...c, lines } });
-        t += 6 + lines.length * 2;
+        push("COMMENTS_HOST", { ...c, lines }, 2 + lines.length * 2);
         break;
       }
-      case "TRAINING": {
-        timeline.push({ t, cue: "TRAINING", data: c });
-        t += 7;
-        break;
+      case "MORPH_TRAINING": {
+        // Dewey (line→sax) & Sophia (line→square→diamond→circle) sequence
+        push("MORPH_TRAINING", c, 7.5); break;
       }
       case "REVEAL": {
-        timeline.push({ t, cue: "REVEAL", data: c });
-        t += 4;
-        break;
+        push("REVEAL", c, 4.0); break;
       }
       case "LEDGER_CHECK": {
-        // ledger “receipt”
-        receipts.push({ ts: Date.now(), entry: c.ledger.entry, witness: c.ledger.witness });
-        timeline.push({ t, cue: "LEDGER_CHECK", data: c });
-        t += 2.5;
+        const rec = { ts: Date.now(), entry: c.ledger.entry, witness: c.ledger.witness, meta_id: board.meta.id };
+        push("LEDGER_CHECK", c, 2.2, rec);
         break;
       }
       case "NFT_RAIN": {
-        // compute badge previews from zcm_hint
         const drops = c.badges.map(b => {
           const z = zcmFromText(b.zcm_hint || b.desc || b.name);
           return { ...b, zcm: z, zcmScore: +zcmScore(z).toFixed(3) };
         });
-        timeline.push({ t, cue: "NFT_RAIN", data: { ...c, drops } });
-        receipts.push({ ts: Date.now(), nft_rain: drops });
-        t += 3 + drops.length * 1.2;
+        push("NFT_RAIN", { ...c, drops }, 2.8 + drops.length * 1.0, { ts: Date.now(), nft_rain: drops, meta_id: board.meta.id });
+        break;
+      }
+      case "GUESS_PREVIEW": {
+        // continuity breadcrumb: end-of-episode teaser
+        const teaser = { ...c.teaser, meta_id: board.meta.id, title: board.meta.title };
+        push("GUESS_PREVIEW", teaser, 2.5, { teaser });
+        break;
+      }
+      case "AWARD_MFT": {
+        // award: log receipt
+        push("AWARD_MFT", c, 1.8, { mft: c.winner, meta_id: board.meta.id });
+        break;
+      }
+      case "SFX": {
+        const timelineSfx = resolveSfx(c.names);
+        push("SFX", { names: c.names, resolved: timelineSfx }, 1.2);
         break;
       }
       case "OUTRO": {
-        timeline.push({ t, cue: "OUTRO", data: c });
-        t += 2.5;
-        break;
+        push("OUTRO", c, 2.5); break;
       }
     }
   }
+
+  // write/return receipts (auto-ledger)
+  writeAutoReceipts(board.meta.id, receipts);
   return { timeline, receipts };
 }
+

--- a/spirl-storyboard/src/index.ts
+++ b/spirl-storyboard/src/index.ts
@@ -3,26 +3,67 @@ import fs from "node:fs";
 import { parseYaml } from "./schema";
 import { expand } from "./cues";
 import { renderHTML } from "./render";
+import { aggregateLedger } from "./ledger";
+import { buildNextEpisodeYaml } from "./continuity";
 
-function usage(){ console.log("usage: node dist/index.js <lint|expand|html> <file.yml> [out.json|out.html]"); }
+function usage(){
+  console.log("usage:");
+  console.log(" node dist/index.js lint <file.yml>");
+  console.log(" node dist/index.js expand <file.yml> [out.json]");
+  console.log(" node dist/index.js html <file.yml> [out.html]");
+  console.log(" node dist/index.js ledger build [out.json]");
+  console.log(" node dist/index.js chain next <prev.json> <out.yml>");
+}
 
 async function main(){
-  const [,,cmd, file, out] = process.argv;
-  if (!cmd || !file) return usage();
-  const yml = fs.readFileSync(file, "utf-8");
-  const board = parseYaml(yml);
-  if (cmd==="lint"){ console.log("OK:", board.meta.title); return; }
-  const { timeline, receipts } = expand(board);
+  const [,,cmd,a,b] = process.argv;
+  if (!cmd) return usage();
+
+  if (cmd==="lint"){
+    const y=fs.readFileSync(a,"utf-8"); parseYaml(y); console.log("OK");
+    return;
+  }
   if (cmd==="expand"){
+    const y=fs.readFileSync(a,"utf-8"); const board=parseYaml(y);
+    const { timeline, receipts } = expand(board);
     const json = JSON.stringify({ meta: board.meta, timeline, receipts }, null, 2);
-    if (out) fs.writeFileSync(out, json); else console.log(json);
+    if (b) fs.writeFileSync(b, json); else console.log(json);
     return;
   }
   if (cmd==="html"){
+    const y=fs.readFileSync(a,"utf-8"); const board=parseYaml(y);
+    const { timeline } = expand(board);
     const html = renderHTML(board.meta.title, timeline);
-    if (out) fs.writeFileSync(out, html); else console.log(html);
+    if (b) fs.writeFileSync(b, html); else console.log(html);
+    return;
+  }
+  if (cmd==="ledger" && a==="build"){
+    const agg = aggregateLedger();
+    const out = b || "out/ledger_aggregate.json";
+    fs.mkdirSync("out", { recursive:true });
+    fs.writeFileSync(out, JSON.stringify(agg,null,2));
+    console.log("wrote", out);
+    return;
+  }
+  if (cmd==="chain" && a==="next"){
+    // previous teaser or expanded json input
+    const prev = JSON.parse(fs.readFileSync(b,"utf-8"));
+    const teaser = prev.teaser || prev.receipts?.find((r:any)=>r.teaser)?.teaser;
+    if (!teaser) { console.error("no teaser found in input"); process.exit(1); }
+    const nextMeta = {
+      id: teaser.tease_id+"-EP",
+      title: "Next Mystery",
+      episode: "SxEy",
+      date: new Date().toISOString().slice(0,10),
+      cast: ["Kap","Greg","Dewey","Sophia",".Q"]
+    };
+    const yml = buildNextEpisodeYaml(teaser, nextMeta);
+    const out = "out/next_episode.yml";
+    fs.mkdirSync("out",{recursive:true}); fs.writeFileSync(out, yml);
+    console.log("wrote", out);
     return;
   }
   usage();
 }
 main().catch(e=>{ console.error(e); process.exit(1); });
+

--- a/spirl-storyboard/src/ledger.ts
+++ b/spirl-storyboard/src/ledger.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const LEDGER_DIR = "out/ledger"; // text-only receipts live here
+
+export function writeAutoReceipts(metaId: string, receipts: any[]){
+  try { fs.mkdirSync(LEDGER_DIR, { recursive: true }); } catch {}
+  const p = path.join(LEDGER_DIR, `${sanitize(metaId)}.jsonl`);
+  const lines = receipts.map(r => JSON.stringify(r));
+  fs.appendFileSync(p, lines.join("\n") + "\n");
+}
+
+function sanitize(s: string){ return s.replace(/[^A-Za-z0-9._-]/g, "_"); }
+
+export function aggregateLedger(): any[] {
+  try {
+    const files = fs.readdirSync(LEDGER_DIR).filter(f => f.endsWith(".jsonl"));
+    const all: any[] = [];
+    for (const f of files){
+      const text = fs.readFileSync(path.join(LEDGER_DIR, f), "utf-8");
+      for (const line of text.split("\n")){
+        if (!line.trim()) continue;
+        try { all.push(JSON.parse(line)); } catch {}
+      }
+    }
+    // sort by timestamp
+    all.sort((a,b)=> (a.ts||0) - (b.ts||0));
+    return all;
+  } catch { return []; }
+}
+

--- a/spirl-storyboard/src/schema.ts
+++ b/spirl-storyboard/src/schema.ts
@@ -1,40 +1,40 @@
 import yaml from "js-yaml";
 
 export type CueName =
-  | "SCROLL_OPEN" | "COMMENTS_HOST" | "TRAINING" | "REVEAL"
-  | "LEDGER_CHECK" | "NFT_RAIN" | "OUTRO";
+  | "SCROLL_OPEN" | "COMMENTS_HOST" | "MORPH_TRAINING" | "REVEAL"
+  | "LEDGER_CHECK" | "NFT_RAIN" | "OUTRO"
+  | "GUESS_PREVIEW" | "AWARD_MFT" | "SFX";
 
-export type CommentLine = { by: "greg"|"viewer"|"npc"; text: string };
+export type CommentLine = { by: "greg"|"viewer"|"npc"; text: string; user?: string };
 
 export interface Storyboard {
   meta: {
     id: string; title: string; episode: string; date: string;
     cast: string[]; // ["Kap","Greg","Dewey","Sophia",".Q"]
+    prev_id?: string;           // continuity pointer
   };
   cues: Array<
     | { cue: "SCROLL_OPEN"; vo: string; bg?: string }
     | { cue: "COMMENTS_HOST"; host: "Greg"; comments: CommentLine[]; riff?: string }
-    | { cue: "TRAINING"; track: string; morphs: string[]; interject?: string[] }
+    | { cue: "MORPH_TRAINING"; dewey_track: string; sophia_track: string; sequence: string[] }
     | { cue: "REVEAL"; forms: string[]; bridge?: string; typewriter: string[] }
     | { cue: "LEDGER_CHECK"; ledger: { entry: string; witness: string } }
     | { cue: "NFT_RAIN"; badges: Array<{name:string; desc:string; zcm_hint?:string}>; sparkle?: string }
+    | { cue: "GUESS_PREVIEW"; teaser: { silhouette: string; hint: string; tease_id: string } }
+    | { cue: "AWARD_MFT"; winner: { user: string; guess: string; award: string } }
+    | { cue: "SFX"; names: string[] }
     | { cue: "OUTRO"; cta: string; confetti?: boolean }
   >;
 }
 
 export function parseYaml(yml: string): Storyboard {
   const obj = yaml.load(yml) as any;
-  // minimal structural checks
   if (!obj?.meta?.id || !obj?.meta?.title || !Array.isArray(obj?.cues)) {
     throw new Error("Invalid storyboard: missing meta.id/meta.title/cues[]");
   }
-  // Validate cue entries
   for (const c of obj.cues) {
-    if (!c?.cue) throw new Error("Cue missing 'cue' field");
-    const name = c.cue as CueName;
-    if (!["SCROLL_OPEN","COMMENTS_HOST","TRAINING","REVEAL","LEDGER_CHECK","NFT_RAIN","OUTRO"].includes(name)) {
-      throw new Error(`Unknown cue: ${name}`);
-    }
+    if (!c?.cue) throw new Error("Cue missing 'cue'");
   }
   return obj as Storyboard;
 }
+

--- a/spirl-storyboard/src/sfx.ts
+++ b/spirl-storyboard/src/sfx.ts
@@ -1,0 +1,15 @@
+export type SfxCue = "BELL_TOLL"|"SEAGULLS"|"FOG_HORN"|"CLAP"|"CONFETTI_POP"|"LAUGH";
+
+const SFX: Record<SfxCue, { label: string; dur: number }> = {
+  BELL_TOLL:   { label: "🔔 BeLL TOLL DONG DONG", dur: 1.6 },
+  SEAGULLS:    { label: "🕊️ Seagull caws", dur: 1.2 },
+  FOG_HORN:    { label: "📣 Fog horn", dur: 1.8 },
+  CLAP:        { label: "👏 Clapping", dur: 1.5 },
+  CONFETTI_POP:{ label: "🎉 Confetti pops", dur: 1.2 },
+  LAUGH:       { label: "😂 Laughter", dur: 1.7 }
+};
+
+export function resolveSfx(names: string[]){
+  return names.map(n => (SFX[n as SfxCue] || { label: n, dur: 1.0 }));
+}
+

--- a/spirl-storyboard/test/continuity.test.ts
+++ b/spirl-storyboard/test/continuity.test.ts
@@ -1,0 +1,15 @@
+import { buildNextEpisodeYaml } from "../src/continuity";
+import { parseYaml } from "../src/schema";
+
+describe("continuity", () => {
+  it("builds a next episode scaffold with preview & comments host", () => {
+    const yml = buildNextEpisodeYaml(
+      { meta_id:"spq-2025-08-29", title:"Penguin Mug", silhouette:"mug-ish blob", hint:"mug-handle", tease_id:"tease-001" },
+      { id:"next-001", title:"Next Mystery", episode:"S1E13", date:"2025-08-30", cast:["Kap","Greg","Dewey","Sophia",".Q"] }
+    );
+    const b = parseYaml(yml);
+    expect(b.cues.some(c=>c.cue==="COMMENTS_HOST")).toBe(true);
+    expect(b.cues.some(c=>c.cue==="GUESS_PREVIEW")).toBe(true);
+  });
+});
+

--- a/spirl-storyboard/test/cues.test.ts
+++ b/spirl-storyboard/test/cues.test.ts
@@ -10,30 +10,31 @@ cues:
     host: "Greg"
     comments:
       - {by: viewer, text: "It’s a mug"}
-      - {by: viewer, text: "No, it’s the penguin!!"}
       - {by: greg,   text: "Let me find out!!"}
-  - cue: TRAINING
-    track: "Dewey riff"
-    morphs: ["2D outline","inflate","spin"]
+  - cue: MORPH_TRAINING
+    dewey_track: "SP1RL_Saxophone"
+    sophia_track: "A-BLOOM_Line"
+    sequence: ["dot→line","line→square","square→diamond","diamond→circle"]
   - cue: REVEAL
     forms: ["Mug","Handle","Penguin-bridge"]
-    typewriter: ["Ledger: PENGUIN_MUG", "Apéry witness .Q"]
+    typewriter: ["Ledger: PENGUIN_MUG","Witness: .Q"]
   - cue: LEDGER_CHECK
     ledger: { entry: "PENGUIN_MUG", witness: ".Q" }
-  - cue: NFT_RAIN
-    badges:
-      - {name: "MugLife", desc: "coffee lovers", zcm_hint: "story cozy"}
-      - {name: "BirdBrain", desc: "penguin pun", zcm_hint: "sarcasm lol"}
+  - cue: SFX
+    names: ["BELL_TOLL","SEAGULLS"]
+  - cue: GUESS_PREVIEW
+    teaser: { silhouette: "blob", hint: "mug", tease_id: "tease-001" }
   - cue: OUTRO
-    cta: "Drop your guess for tomorrow!"
+    cta: "Drop your guess!"
 `;
 
 describe("expand", () => {
-  it("produces a timeline with receipts", () => {
+  it("produces timeline and receipts for ledger & teaser", () => {
     const b = parseYaml(Y);
     const { timeline, receipts } = expand(b);
-    expect(timeline.length).toBeGreaterThan(3);
-    expect(receipts.find(r=>r.entry==="PENGUIN_MUG")).toBeTruthy();
-    expect(timeline.some(ev => ev.cue==="NFT_RAIN")).toBe(true);
+    expect(timeline.some(ev => ev.cue==="SFX")).toBe(true);
+    expect(receipts.some(r=>r.entry==="PENGUIN_MUG")).toBe(true);
+    expect(receipts.some(r=>r.teaser?.tease_id==="tease-001")).toBe(true);
   });
 });
+

--- a/spirl-storyboard/test/ledger.test.ts
+++ b/spirl-storyboard/test/ledger.test.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import { writeAutoReceipts, aggregateLedger } from "../src/ledger";
+
+describe("ledger", () => {
+  it("appends and aggregates receipts", () => {
+    fs.rmSync("out/ledger", { recursive:true, force:true });
+    writeAutoReceipts("ep1", [{ts:1, entry:"E1", witness:".Q"}]);
+    writeAutoReceipts("ep2", [{ts:2, entry:"E2", witness:".Q"}]);
+    const agg = aggregateLedger();
+    expect(agg.length).toBe(2);
+    expect(agg[0].entry).toBe("E1");
+  });
+});
+

--- a/spirl-storyboard/test/sfx.test.ts
+++ b/spirl-storyboard/test/sfx.test.ts
@@ -1,0 +1,9 @@
+import { resolveSfx } from "../src/sfx";
+
+describe("SFX", () => {
+  it("resolves known sfx labels", () => {
+    const xs = resolveSfx(["BELL_TOLL","SEAGULLS","FOG_HORN","CLAP","CONFETTI_POP","LAUGH"]);
+    expect(xs.some(x=>/BeLL TOLL/.test(x.label))).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend storyboard schema with new cues like GUESS_PREVIEW, AWARD_MFT, SFX, and MORPH_TRAINING
- implement auto-ledger receipts, continuity builder, and stock SFX resolver
- add CLI commands for ledger aggregation and chaining next episode

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: Cannot find type definition file for 'vitest/globals')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b204a36bc483278f1c4f0f0b0ff472