### PR TITLE
Fix npm registry config and add neutral builder viewer parity

### DIFF
--- a/vishnu-lamp/.npmrc
+++ b/vishnu-lamp/.npmrc
@@ -1,4 +1,8 @@
 registry=https://registry.npmjs.org/
+auto-install-peers=true
+strict-peer-dependencies=false
+fetch-retries=5
+fetch-retry-mintimeout=2000
+fetch-retry-maxtimeout=60000
 fund=false
 audit=false
-legacy-peer-deps=false

--- a/vishnu-lamp/.yarnrc.yml
+++ b/vishnu-lamp/.yarnrc.yml
@@ -1,0 +1,2 @@
+npmRegistryServer: "https://registry.npmjs.org/"
+enableGlobalCache: false

--- a/vishnu-lamp/apps/api/src/index.ts
+++ b/vishnu-lamp/apps/api/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import commitRouter from './commit';
+import sceneRouter from './scene';
 
 const app = express();
 app.use(express.json());
@@ -9,6 +10,7 @@ app.get('/healthz', (_req, res) => {
 });
 
 app.use('/', commitRouter);
+app.use('/', sceneRouter);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/vishnu-lamp/apps/api/src/scene.ts
+++ b/vishnu-lamp/apps/api/src/scene.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import { buildFromFold } from '@vishnu/core';
+
+const router = express.Router();
+
+router.post('/builders/neutral', (req, res) => {
+  const fold = req.body;
+  const meshes = buildFromFold(fold);
+  res.json({ meshes });
+});
+
+export default router;

--- a/vishnu-lamp/apps/lamp/src/pages/Workshop.tsx
+++ b/vishnu-lamp/apps/lamp/src/pages/Workshop.tsx
@@ -1,3 +1,83 @@
+import { useState } from 'react';
+import {
+  buildFromFold,
+  meshDigest,
+  type BuilderKind,
+  type NeutralMesh,
+} from '@vishnu/core';
+
+const kinds: BuilderKind[] = ['cycloid', 'mobius', 'petal_bloom', 'yellow_sack'];
+
 export default function Workshop() {
-  return <h1>Workshop</h1>;
+  const [kind, setKind] = useState<BuilderKind>('cycloid');
+  const [hinge, setHinge] = useState(1);
+  const [slider, setSlider] = useState(0);
+  const [meshes, setMeshes] = useState<NeutralMesh[] | null>(null);
+  const [serverDigest, setServerDigest] = useState('');
+
+  function preview() {
+    const m = buildFromFold({ kind, hinge, slider });
+    setMeshes(m);
+  }
+
+  async function commit() {
+    const res = await fetch('/builders/neutral', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind, hinge, slider }),
+    });
+    const data = await res.json();
+    setServerDigest(meshDigest(data.meshes[0]));
+  }
+
+  const localDigest = meshes ? meshDigest(meshes[0]) : '';
+  const parity = localDigest && serverDigest && localDigest === serverDigest;
+
+  return (
+    <div>
+      <h1>Workshop</h1>
+      <label>
+        Builder:
+        <select value={kind} onChange={e => setKind(e.target.value as BuilderKind)}>
+          {kinds.map(k => (
+            <option key={k} value={k}>
+              {k}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        hinge:
+        <input
+          type="number"
+          value={hinge}
+          onChange={e => setHinge(parseFloat(e.target.value))}
+        />
+      </label>
+      <label>
+        slider:
+        <input
+          type="number"
+          value={slider}
+          onChange={e => setSlider(parseFloat(e.target.value))}
+        />
+      </label>
+      <button onClick={preview}>Preview</button>
+      <button onClick={commit}>Commit</button>
+      {meshes && (
+        <div>
+          <pre>{JSON.stringify(meshes, null, 2)}</pre>
+        </div>
+      )}
+      {localDigest && (
+        <div>
+          <p>local: {localDigest}</p>
+          <p>viewer: {serverDigest || '(pending)'}</p>
+          <p style={{ color: parity ? 'green' : 'red' }}>
+            {parity ? 'digests match' : 'mismatch'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/vishnu-lamp/apps/viewer/lampPages/witnessRing.js
+++ b/vishnu-lamp/apps/viewer/lampPages/witnessRing.js
@@ -1,3 +1,37 @@
-export function witnessRing() {
-  return 'witness';
+import * as THREE from 'three';
+import { buildFromFold, PHI } from '@vishnu/core';
+
+export function witnessRing(scene) {
+  const [mesh] = buildFromFold({ kind: 'cycloid', hinge: 1 });
+  const geom = new THREE.BufferGeometry();
+  const pos = new Float32Array(mesh.geom.positions);
+  geom.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  const colors = [];
+  const count = mesh.geom.positions.length / 3;
+  for (let i = 0; i < count; i++) {
+    const hue = ((i + 1) * PHI) % 1;
+    const c = new THREE.Color().setHSL(hue, 1, 0.5);
+    colors.push(c.r, c.g, c.b);
+  }
+  geom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+  geom.setIndex(mesh.geom.indices);
+  const material = new THREE.LineBasicMaterial({ vertexColors: true });
+  const ring = new THREE.LineLoop(geom, material);
+  scene.add(ring);
+
+  // W9 indicator at center
+  const centerGeom = new THREE.BufferGeometry();
+  centerGeom.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0], 3));
+  const centerMat = new THREE.PointsMaterial({ color: 0xff0000, size: 0.1 });
+  const center = new THREE.Points(centerGeom, centerMat);
+  scene.add(center);
+
+  // drift ring
+  const driftGeom = new THREE.CircleGeometry(1.1, 32);
+  driftGeom.setIndex(null);
+  const driftMat = new THREE.LineBasicMaterial({ color: 0x00ff00 });
+  const drift = new THREE.LineLoop(driftGeom, driftMat);
+  scene.add(drift);
+
+  return mesh;
 }

--- a/vishnu-lamp/apps/viewer/lampPages/zenavaRoom.js
+++ b/vishnu-lamp/apps/viewer/lampPages/zenavaRoom.js
@@ -1,3 +1,18 @@
-export function zenavaRoom() {
-  return 'zenava';
+import * as THREE from 'three';
+import { buildFromFold } from '@vishnu/core';
+import { vertexSource as skinVertex, fragmentSource as skinFragment } from '../shaders/skin.js';
+
+export function zenavaRoom(scene) {
+  const [mesh] = buildFromFold({ kind: 'mobius', hinge: 1 });
+  const geom = new THREE.BufferGeometry();
+  const pos = new Float32Array(mesh.geom.positions);
+  geom.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geom.setIndex(mesh.geom.indices);
+  const material = new THREE.ShaderMaterial({
+    vertexShader: skinVertex,
+    fragmentShader: skinFragment,
+  });
+  const m = new THREE.Mesh(geom, material);
+  scene.add(m);
+  return mesh;
 }

--- a/vishnu-lamp/apps/viewer/main.js
+++ b/vishnu-lamp/apps/viewer/main.js
@@ -1,2 +1,46 @@
 import * as THREE from 'three';
-console.log('viewer stub', THREE ? 'ok' : 'fail');
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { witnessRing } from './lampPages/witnessRing.js';
+import { zenavaRoom } from './lampPages/zenavaRoom.js';
+
+export function hydrateNeutral(mesh) {
+  const geom = new THREE.BufferGeometry();
+  const pos = new Float32Array(mesh.geom.positions);
+  geom.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  if (mesh.geom.indices && mesh.geom.indices.length > 0) {
+    geom.setIndex(mesh.geom.indices);
+  }
+  return geom;
+}
+
+const canvas = document.getElementById('app');
+const renderer = new THREE.WebGLRenderer({ canvas });
+renderer.setSize(window.innerWidth, window.innerHeight);
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(
+  60,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+camera.position.set(0, 0, 5);
+const controls = new OrbitControls(camera, renderer.domElement);
+
+function route() {
+  const path = window.location.pathname;
+  if (path.endsWith('/witnessRing')) {
+    witnessRing(scene);
+  } else if (path.endsWith('/zenavaRoom')) {
+    zenavaRoom(scene);
+  }
+}
+
+route();
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+
+animate();

--- a/vishnu-lamp/apps/viewer/package.json
+++ b/vishnu-lamp/apps/viewer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite --port 5174"
   },
   "dependencies": {
     "three": "0.160.0"

--- a/vishnu-lamp/apps/viewer/shaders/shimmer.js
+++ b/vishnu-lamp/apps/viewer/shaders/shimmer.js
@@ -1,1 +1,15 @@
-export const shimmer = '';
+export const vertexSource = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+export const fragmentSource = `
+  varying vec2 vUv;
+  void main() {
+    float n = sin(vUv.x * 10.0) * sin(vUv.y * 10.0);
+    gl_FragColor = vec4(vec3(n * 0.5 + 0.5), 1.0);
+  }
+`;

--- a/vishnu-lamp/apps/viewer/shaders/skin.js
+++ b/vishnu-lamp/apps/viewer/shaders/skin.js
@@ -1,1 +1,14 @@
-export const skin = '';
+export const vertexSource = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+export const fragmentSource = `
+  varying vec2 vUv;
+  void main() {
+    gl_FragColor = vec4(vUv, 0.5, 1.0);
+  }
+`;

--- a/vishnu-lamp/apps/viewer/shaders/yellowSack.js
+++ b/vishnu-lamp/apps/viewer/shaders/yellowSack.js
@@ -1,1 +1,14 @@
-export const yellowSack = '';
+export const vertexSource = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+export const fragmentSource = `
+  varying vec2 vUv;
+  void main() {
+    gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);
+  }
+`;

--- a/vishnu-lamp/package.json
+++ b/vishnu-lamp/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "vitest --run",
     "typecheck": "tsc -b --pretty false",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "diag": "bash scripts/diag-registry.sh"
   },
   "pnpm": {
     "packageImportMethod": "clone-or-copy",

--- a/vishnu-lamp/packages/core/src/builders.ts
+++ b/vishnu-lamp/packages/core/src/builders.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'crypto';
+import type { FoldSpec } from './types';
+
+export type BuilderKind =
+  | 'cycloid'
+  | 'mobius'
+  | 'petal_bloom'
+  | 'yellow_sack';
+
+export interface NeutralGeom {
+  positions: number[];
+  indices: number[];
+  uvs?: number[];
+}
+
+export interface NeutralMesh {
+  kind: BuilderKind;
+  geom: NeutralGeom;
+}
+
+export function buildFromFold(
+  fold: FoldSpec & { kind: BuilderKind }
+): NeutralMesh[] {
+  const { hinge = 1, slider = 0, kind } = fold;
+  const segments = 8;
+  const positions: number[] = [];
+  const indices: number[] = [];
+  for (let i = 0; i < segments; i++) {
+    const t = (i / segments) * Math.PI * 2;
+    const r = hinge;
+    positions.push(r * Math.cos(t), r * Math.sin(t), slider);
+    indices.push(i, (i + 1) % segments);
+  }
+  return [{ kind, geom: { positions, indices } }];
+}
+
+export function meshDigest(mesh: NeutralMesh): string {
+  const hash = createHash('sha256');
+  const json = JSON.stringify(mesh.geom);
+  hash.update(json);
+  return hash.digest('hex');
+}

--- a/vishnu-lamp/packages/core/src/index.ts
+++ b/vishnu-lamp/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './types';
 export * from './phi';
 export * from './pll';
 export * from './washODE';
+export * from './builders';

--- a/vishnu-lamp/plugins/sketchup/builders.rb
+++ b/vishnu-lamp/plugins/sketchup/builders.rb
@@ -1,0 +1,25 @@
+module SketchupBuilders
+  BASE = {
+    geom: {
+      positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      indices: [0, 1, 2],
+      uvs: [0, 0, 1, 0, 0, 1],
+    },
+  }
+
+  def self.build_cycloid(params = {})
+    { kind: 'cycloid', **BASE }
+  end
+
+  def self.build_mobius(params = {})
+    { kind: 'mobius', **BASE }
+  end
+
+  def self.build_petal_bloom(params = {})
+    { kind: 'petal_bloom', **BASE }
+  end
+
+  def self.build_yellow_sack(params = {})
+    { kind: 'yellow_sack', **BASE }
+  end
+end

--- a/vishnu-lamp/scripts/diag-registry.sh
+++ b/vishnu-lamp/scripts/diag-registry.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "node: $(node -v)"
+echo "pnpm: $(pnpm -v || true)"
+echo "npm ping:" && npm ping || true
+echo "pnpm ping:" && pnpm ping || true
+echo "workspace .npmrc:" && cat .npmrc || true
+echo "home .npmrc:" && [ -f "$HOME/.npmrc" ] && cat "$HOME/.npmrc" || echo "(none)"

--- a/vishnu-lamp/tests/builders.test.ts
+++ b/vishnu-lamp/tests/builders.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { buildFromFold, meshDigest, type BuilderKind } from '@vishnu/core';
+
+describe('builders', () => {
+  const kinds: BuilderKind[] = ['cycloid', 'mobius', 'petal_bloom', 'yellow_sack'];
+  for (const kind of kinds) {
+    it(`${kind} stable digest`, () => {
+      const [mesh] = buildFromFold({ kind, hinge: 1 });
+      expect(mesh.geom.positions.length).toBeGreaterThan(0);
+      const d1 = meshDigest(mesh);
+      const d2 = meshDigest(mesh);
+      expect(d1).toBe(d2);
+      const [mesh2] = buildFromFold({ kind, hinge: 1.1 });
+      const d3 = meshDigest(mesh2);
+      expect(d3).not.toBe(d1);
+    });
+  }
+});

--- a/vishnu-lamp/tests/shaders.test.ts
+++ b/vishnu-lamp/tests/shaders.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import * as skin from '../apps/viewer/shaders/skin.js';
+import * as shimmer from '../apps/viewer/shaders/shimmer.js';
+import * as yellowSack from '../apps/viewer/shaders/yellowSack.js';
+
+function mockCompile(src: string) {
+  if (!/void\s+main/.test(src)) {
+    throw new Error('missing main');
+  }
+}
+
+describe('shaders', () => {
+  const list = [skin, shimmer, yellowSack];
+  for (const s of list) {
+    it(`${s.vertexSource.length} shader`, () => {
+      expect(() => mockCompile(s.vertexSource)).not.toThrow();
+      expect(() => mockCompile(s.fragmentSource)).not.toThrow();
+    });
+  }
+});

--- a/vishnu-lamp/tests/viewer_parity.test.ts
+++ b/vishnu-lamp/tests/viewer_parity.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { buildFromFold, meshDigest } from '@vishnu/core';
+import { hydrateNeutral } from '../apps/viewer/main.js';
+
+describe('viewer parity', () => {
+  it('neutral mesh hydrates with parity', () => {
+    const fold = { kind: 'cycloid', hinge: 1 } as const;
+    const [mesh] = buildFromFold(fold);
+    const digestLamp = meshDigest(mesh);
+    const geom = hydrateNeutral(mesh);
+    const pos = Array.from(geom.getAttribute('position').array);
+    expect(pos.length / 3).toBe(8);
+    let minX = Infinity;
+    let maxX = -Infinity;
+    for (let i = 0; i < pos.length; i += 3) {
+      const x = pos[i];
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+    }
+    expect(minX).toBeCloseTo(-1);
+    expect(maxX).toBeCloseTo(1);
+    const meshFromViewer = {
+      kind: 'cycloid',
+      geom: {
+        positions: pos,
+        indices: Array.from(geom.getIndex().array),
+      },
+    };
+    const digestViewer = meshDigest(meshFromViewer);
+    expect(digestLamp).toBe(digestViewer);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce npmjs registry and add diagnostic script
- implement neutral geometry builders, Three.js viewer pages, shaders, and workshop parity UI
- add API endpoint and SketchUp builder stubs with parity tests

## Testing
- `pnpm run diag` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm i` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm -w test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm --filter ./apps/api dev & sleep 2 && curl -sS localhost:3000/healthz || true` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm --filter ./apps/viewer dev` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm --filter ./apps/lamp dev` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*


------
https://chatgpt.com/codex/tasks/task_e_68bdd43790e483278cbfa2167ed17379