### PR TITLE
feat: add chat braid flow

### DIFF
--- a/vishnu-lamp/README.md
+++ b/vishnu-lamp/README.md
@@ -56,3 +56,9 @@ in the WAL under `REACTOR_UPDATE`. Visit the **Reactor** tab in the Lamp to dial
 phases, tweak chemistry, and watch the Y‑fork lamp spawn. Telemetry stores the
 latest reactor state in the ledger for replay. See [docs/reactor.md](docs/reactor.md)
 for the myth → math breakdown.
+
+## Chat Braid
+
+Tag transcripts with `[iN] [oN] [oNYiN] [YaNg] [YiN]` and visit the Chat page to
+parse, score, and mint petals. See [docs/chat-braid.md](docs/chat-braid.md) for
+grammar and scoring details.

--- a/vishnu-lamp/apps/api/src/chat.ts
+++ b/vishnu-lamp/apps/api/src/chat.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import { appendEvent } from './wal';
+import { reduceViews, getState } from './views';
+import { PetalChunk, scoreChunk } from '../../packages/core/src';
+
+const r = express.Router();
+
+r.post('/chat/ingest', async (req, res) => {
+  const { chunk } = req.body as { chunk: PetalChunk };
+  if (!chunk?.turns?.length)
+    return res.status(400).json({ error: 'empty chunk' });
+  await appendEvent({
+    type: 'CHAT_INSERTED',
+    payload: { chunk },
+    status: 'OK',
+  });
+  await reduceViews();
+  res.json({ ok: true, id: chunk.id });
+});
+
+r.post('/chat/score', async (req, res) => {
+  const { chunk } = req.body as { chunk: PetalChunk };
+  if (!chunk) return res.status(400).json({ error: 'missing chunk' });
+  const scored = scoreChunk(chunk);
+  await appendEvent({
+    type: 'CHAT_SCORED',
+    payload: { chunkId: scored.id, scores: scored.scores },
+    status: 'OK',
+  });
+  await reduceViews();
+  res.json({ ok: true, scores: scored.scores });
+});
+
+r.post('/chat/mint', async (req, res) => {
+  const { chunkId, human } = req.body as { chunkId: string; human: boolean };
+  if (!chunkId) return res.status(400).json({ error: 'missing chunkId' });
+  if (!human) return res.status(400).json({ error: '.su approval required' });
+  const state = getState();
+  const petal = (state as any).petal_index?.[chunkId];
+  const aiOK = (petal?.scores?.zcm ?? 0) >= 0.8;
+  if (!aiOK) return res.status(400).json({ error: '.ai declined (zcm too low)' });
+  await appendEvent({
+    type: 'CHAT_MINTED',
+    payload: { chunkId, primeAddress: 'PP:TP(89)@φ43:34:step34~J:1' },
+    status: 'OK',
+  });
+  await reduceViews();
+  res.json({ ok: true });
+});
+
+r.get('/chat/:id', (req, res) => {
+  const state = getState();
+  const chunk = (state as any).petal_index?.[req.params.id];
+  if (!chunk) return res.status(404).json({ error: 'not found' });
+  res.json(chunk);
+});
+
+export default r;

--- a/vishnu-lamp/apps/api/src/index.ts
+++ b/vishnu-lamp/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import zenavaRouter from './zenava';
 import ghostRouter from './ghost';
 import uploadRouter from './upload';
 import reactorRouter from './reactor';
+import chatRouter from './chat';
 
 const app = express();
 app.use(express.json());
@@ -21,6 +22,7 @@ app.use('/', zenavaRouter);
 app.use('/', ghostRouter);
 app.use('/', uploadRouter);
 app.use('/reactor', reactorRouter);
+app.use(chatRouter);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/vishnu-lamp/apps/api/src/views.ts
+++ b/vishnu-lamp/apps/api/src/views.ts
@@ -123,3 +123,46 @@ export async function writeUploadJob(job: UploadJob): Promise<void> {
   await fs.mkdir(UPLOAD_DIR, { recursive: true });
   await fs.writeFile(new URL(`${job.id}.json`, UPLOAD_DIR), JSON.stringify(job, null, 2));
 }
+
+interface ViewsState {
+  petal_index: Record<string, any>;
+}
+
+const state: ViewsState = { petal_index: {} };
+
+export function getState(): ViewsState {
+  return state;
+}
+
+export async function reduceViews(): Promise<void> {
+  const events = await readAll();
+  state.petal_index = {};
+  for (const e of events) {
+    if (e.type === 'CHAT_INSERTED') {
+      const { chunk } = e.payload as any;
+      const participants = Array.from(
+        new Set((chunk.turns || []).map((t: any) => t.role).filter(Boolean))
+      );
+      state.petal_index[chunk.id] = {
+        turns: chunk.turns,
+        participants,
+        closure: chunk.closure,
+      };
+    } else if (e.type === 'CHAT_SCORED') {
+      const { chunkId, scores } = e.payload as any;
+      const item = state.petal_index[chunkId];
+      if (item) {
+        item.scores = scores;
+        item.witnessSector = Math.floor(Date.now() / 137) % 8;
+        item.bloomLayer = scores.coherence > 0.75 ? 'outer' : 'inner';
+      }
+    } else if (e.type === 'CHAT_MINTED') {
+      const { chunkId, primeAddress } = e.payload as any;
+      const item = state.petal_index[chunkId];
+      if (item) {
+        item.minted = true;
+        item.primeAddress = primeAddress;
+      }
+    }
+  }
+}

--- a/vishnu-lamp/apps/api/src/wal.ts
+++ b/vishnu-lamp/apps/api/src/wal.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
 import type { ReactorState } from '@vishnu/core/reactorMath';
 
 export type WalEventType =
@@ -18,7 +19,10 @@ export type WalEventType =
   | 'MINT'
   | 'UPLOAD_RECEIVED'
   | 'UPLOAD_FABRICATED'
-  | 'REACTOR_UPDATE';
+  | 'REACTOR_UPDATE'
+  | 'CHAT_INSERTED'
+  | 'CHAT_SCORED'
+  | 'CHAT_MINTED';
 
 export interface WalEvent {
   id: string;
@@ -38,6 +42,22 @@ const WAL_PATH = new URL('../../data/wal.log', import.meta.url);
 
 export async function append(event: WalEvent): Promise<void> {
   await fs.appendFile(WAL_PATH, JSON.stringify(event) + '\n');
+}
+
+export async function appendEvent(
+  evt: Omit<WalEvent, 'id' | 't' | 'scene_id' | 'user_id' | 'req_id' | 'model_semver' | 'kernel_digest'>
+): Promise<void> {
+  const event: WalEvent = {
+    id: randomUUID(),
+    t: new Date().toISOString(),
+    scene_id: 'default',
+    user_id: 'u-0',
+    req_id: randomUUID(),
+    model_semver: 'v1.0.0',
+    kernel_digest: 'sha256:none',
+    ...evt,
+  };
+  await append(event);
 }
 
 export async function readAll(): Promise<WalEvent[]> {

--- a/vishnu-lamp/apps/lamp/src/main.tsx
+++ b/vishnu-lamp/apps/lamp/src/main.tsx
@@ -10,12 +10,13 @@ import Theater from './pages/Theater';
 import Ledger from './pages/Ledger';
 import Portholes from './pages/Portholes';
 import Reactor from './pages/Reactor';
+import Chat from './pages/Chat';
 import './styles.css';
 
 const App = () => (
   <BrowserRouter>
     <nav>
-      <Link to="/">Seam</Link> | <Link to="/reactor">Reactor</Link>
+      <Link to="/">Seam</Link> | <Link to="/reactor">Reactor</Link> | <Link to="/chat">Chat</Link>
     </nav>
     <Routes>
       <Route path="/" element={<SeamGate />} />
@@ -27,6 +28,7 @@ const App = () => (
       <Route path="/ledger" element={<Ledger />} />
       <Route path="/portholes" element={<Portholes />} />
       <Route path="/reactor" element={<Reactor />} />
+      <Route path="/chat" element={<Chat />} />
     </Routes>
   </BrowserRouter>
 );

--- a/vishnu-lamp/apps/lamp/src/pages/Chat.tsx
+++ b/vishnu-lamp/apps/lamp/src/pages/Chat.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { parseTranscript, hingeOneLiner } from '../../../packages/core/src';
+import { commit } from '../lib/api';
+import type { PetalChunk } from '../../../packages/core/src/chatBraid';
+
+export default function Chat() {
+  const [lines, setLines] = useState('');
+  const [chunk, setChunk] = useState<PetalChunk | null>(null);
+  const [scores, setScores] = useState<any>(null);
+  const [quip, setQuip] = useState('');
+  const [human, setHuman] = useState(false);
+
+  async function ingest() {
+    const pcs = parseTranscript(lines.split('\n'));
+    if (!pcs.length) return;
+    const pc = pcs[0];
+    setChunk(pc);
+    await fetch('/chat/ingest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chunk: pc }),
+    });
+  }
+
+  async function score() {
+    if (!chunk) return;
+    const res = await fetch('/chat/score', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chunk }),
+    });
+    const data = await res.json();
+    setScores(data.scores);
+    setQuip(hingeOneLiner(chunk.participants[0] ?? '', chunk.participants[1] ?? ''));
+  }
+
+  async function mint() {
+    if (!chunk) return;
+    const res = await fetch('/chat/mint', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chunkId: chunk.id, human }),
+    });
+    if (res.ok) {
+      await replay();
+    }
+  }
+
+  async function replay() {
+    if (!scores) return;
+    const witnessSector = Math.floor(Date.now() / 137) % 8;
+    const bloomLayer = scores.coherence > 0.75 ? 'outer' : 'inner';
+    await commit('default', { witnessSector, bloomLayer });
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: '20px' }}>
+      <div style={{ flex: 1 }}>
+        <textarea
+          value={lines}
+          onChange={(e) => setLines(e.target.value)}
+          rows={10}
+          cols={30}
+        />
+        <div>
+          <button onClick={ingest}>Parse</button>
+          <button onClick={score}>Score</button>
+        </div>
+        <ul>
+          {chunk?.turns.map((t, i) => (
+            <li key={i}>
+              [{t.tag}/{t.role}] {t.surface}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div style={{ flex: 1 }}>
+        {scores && (
+          <div>
+            <p>coherence: {scores.coherence.toFixed(3)}</p>
+            <p>edgeDensity: {scores.edgeDensity.toFixed(3)}</p>
+            <p>leastAction: {scores.leastAction.toFixed(3)}</p>
+            <p>zcm: {scores.zcm.toFixed(3)}</p>
+            <p>{quip}</p>
+          </div>
+        )}
+      </div>
+      <div style={{ flex: 1 }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={human}
+            onChange={(e) => setHuman(e.target.checked)}
+          />{' '}
+          Human approves (.su)
+        </label>
+        <div>
+          <button onClick={mint}>Mint</button>
+          <button onClick={replay}>Replay as Petal</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/vishnu-lamp/docs/chat-braid.md
+++ b/vishnu-lamp/docs/chat-braid.md
@@ -1,0 +1,50 @@
+# Chat Braid
+
+Chat turns carry one of five tags:
+`[iN]`, `[oN]`, `[oNYiN]`, `[YaNg]`, `[YiN]`. A tag may include a role:
+`[iN/host] hello world`. Lines are grouped until `YiN` closes the chunk.
+
+## Example Transcript
+
+```
+[iN/host] Start here
+[oN/user] Reply one
+[oNYiN/host] Small example
+[YaNg/user] Aha!
+[YiN] Done
+```
+
+## Example Chunk JSON
+
+```
+{
+  "id": "...",
+  "participants": ["host", "user"],
+  "turns": [
+    { "tag": "iN", "role": "host", "surface": "Start here", "full": "Start here" },
+    { "tag": "oN", "role": "user", "surface": "Reply one", "full": "Reply one" },
+    { "tag": "oNYiN", "role": "host", "surface": "Small example", "full": "Small example" },
+    { "tag": "YaNg", "role": "user", "surface": "Aha!", "full": "Aha!" },
+    { "tag": "YiN", "role": "", "surface": "Done", "full": "Done" }
+  ],
+  "closure": true
+}
+```
+
+## Scoring
+
+* **coherence** – cosine similarity of adjacent 3‑gram vectors.
+* **edgeDensity** – observed role transitions vs. possible edges.
+* **leastAction** – inverse of turn count.
+* **zcm** – blend of the above used for mint gating.
+
+Mint requires both human `.su` and AI `.ai` approval: `zcm ≥ 0.80`.
+
+## Replay as Petal
+
+The score reducer maps chunks for visualization:
+
+* `witnessSector = (Math.floor(Date.now()/137) % 8)`
+* `bloomLayer = coherence > 0.75 ? 'outer' : 'inner'`
+
+Minted petals add to the bloom and highlight the witness sector.

--- a/vishnu-lamp/packages/core/src/chatBraid.ts
+++ b/vishnu-lamp/packages/core/src/chatBraid.ts
@@ -1,0 +1,128 @@
+export type ChatTag = 'iN' | 'oN' | 'oNYiN' | 'YaNg' | 'YiN';
+export type ChatTurn = {
+  tag: ChatTag;
+  role: string;
+  surface: string;
+  full: string;
+  time?: string;
+  meta?: any;
+};
+export type PetalChunk = {
+  id: string;
+  participants: string[];
+  turns: ChatTurn[];
+  closure: boolean;
+  scores?: {
+    coherence: number;
+    edgeDensity: number;
+    leastAction: number;
+    zcm: number;
+  };
+};
+
+export const TAG_RX = /^\s*[\[\{](iN|oN|oNYiN|YaNg|YiN)(?:\/([a-zA-Z0-9_-]+))?[\]\}]\s*/;
+
+function fnv1a(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export function parseTranscript(lines: string[]): PetalChunk[] {
+  const chunks: PetalChunk[] = [];
+  let cur: PetalChunk | null = null;
+  let acc = '';
+  for (const raw of lines) {
+    if (!raw.trim()) continue;
+    const m = TAG_RX.exec(raw);
+    if (!m) continue;
+    const tag = m[1] as ChatTag;
+    const role = m[2] || '';
+    const surface = raw.slice(m[0].length).trim();
+    const turn: ChatTurn = { tag, role, surface, full: surface };
+    if (!cur) {
+      cur = { id: '', participants: [], turns: [], closure: false };
+      acc = '';
+    }
+    cur.turns.push(turn);
+    acc += `${tag}/${role}:${surface}|`;
+    if (role && !cur.participants.includes(role)) cur.participants.push(role);
+    if (tag === 'YiN') {
+      cur.closure = true;
+      const id = fnv1a(acc).toString(36);
+      cur.id = id;
+      chunks.push(cur);
+      cur = null;
+    }
+  }
+  if (cur) {
+    const id = fnv1a(acc).toString(36);
+    cur.id = id;
+    chunks.push(cur);
+  }
+  return chunks;
+}
+
+function ngramVec(text: string, n = 3): Record<string, number> {
+  const t = text.toLowerCase();
+  const v: Record<string, number> = {};
+  for (let i = 0; i <= t.length - n; i++) {
+    const g = t.slice(i, i + n);
+    v[g] = (v[g] || 0) + 1;
+  }
+  return v;
+}
+
+function cosine(a: Record<string, number>, b: Record<string, number>): number {
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (const k in a) {
+    magA += a[k] * a[k];
+    if (b[k]) dot += a[k] * b[k];
+  }
+  for (const k in b) magB += b[k] * b[k];
+  if (!magA || !magB) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+export function scoreChunk(pc: PetalChunk): PetalChunk {
+  const vecs = pc.turns.map((t) => ngramVec(t.surface));
+  let cohSum = 0;
+  let cohCnt = 0;
+  const edges = new Set<string>();
+  for (let i = 1; i < pc.turns.length; i++) {
+    cohSum += cosine(vecs[i - 1], vecs[i]);
+    cohCnt++;
+    const a = pc.turns[i - 1].role;
+    const b = pc.turns[i].role;
+    if (a && b && a !== b) edges.add(`${a}->${b}`);
+  }
+  const coherence = cohCnt ? cohSum / cohCnt : 0;
+  const participants = pc.participants.length;
+  const possible = participants > 1 ? participants * (participants - 1) : 1;
+  const edgeDensity = edges.size / possible;
+  const leastAction = 1 / Math.max(pc.turns.length, 1);
+  const zcm = (coherence + edgeDensity + (1 - leastAction)) / 3;
+  pc.scores = { coherence, edgeDensity, leastAction, zcm };
+  return pc;
+}
+
+const QUIPS = [
+  'Mind the fold.',
+  'Edges crave closure.',
+  'Spiral sharper, speak clearer.',
+  'Petals gossip in threes.',
+  'Chaos hums in cosine.',
+  'Phi forgives no one.',
+  'Least action, best traction.',
+  'Mint only what blooms.',
+];
+
+export function hingeOneLiner(host: string, user: string): string {
+  const h = fnv1a(`${host}|${user}`);
+  return QUIPS[h % QUIPS.length];
+}

--- a/vishnu-lamp/packages/core/src/index.ts
+++ b/vishnu-lamp/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from './phi';
 export * from './pll';
 export * from './washODE';
 export * from './builders';
+export * from './chatBraid';

--- a/vishnu-lamp/tests/chat_braid.test.ts
+++ b/vishnu-lamp/tests/chat_braid.test.ts
@@ -1,0 +1,39 @@
+const ONLINE = process.env.RUN_ONLINE === '1';
+(ONLINE ? describe : describe.skip)('chat braid', () => {
+  const { parseTranscript, scoreChunk, hingeOneLiner } = require('../packages/core/src');
+
+  it('parses a full chunk', () => {
+    const lines = [
+      '[iN/host] Start here',
+      '[oN/user] Reply one',
+      '[oNYiN/host] Small example',
+      '[YaNg/user] Aha!',
+      '[YiN] Done',
+    ];
+    const chunks = parseTranscript(lines);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].closure).toBe(true);
+    expect(chunks[0].turns.length).toBe(5);
+  });
+
+  it('scores deterministically', () => {
+    const pc = {
+      id: 'pc',
+      participants: ['host', 'user'],
+      closure: true,
+      turns: [
+        { tag: 'iN', role: 'host', surface: 'teach the trick', full: 'teach the trick' },
+        { tag: 'oN', role: 'user', surface: 'confused about trick', full: 'confused about trick' },
+        { tag: 'oNYiN', role: 'host', surface: 'tiny example', full: 'tiny example' },
+        { tag: 'YaNg', role: 'user', surface: 'aha', full: 'aha' },
+        { tag: 'YiN', role: 'host', surface: 'wrap', full: 'wrap' },
+      ],
+    };
+    const s = scoreChunk(pc).scores!;
+    expect(s.coherence).toBeGreaterThan(0);
+    expect(s.leastAction).toBeLessThan(1);
+    const line = hingeOneLiner('host speaks truth', 'user learns trick');
+    expect(typeof line).toBe('string');
+    expect(line.length).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic chat braid parser, scorer, and quip generator
- expose chat braid API with WAL integration and mint gating
- add Lamp chat UI, docs, and tests

## Testing
- `pnpm -w test -r tests/chat_braid.test.ts` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68be57b2163c83279743924a6908e019