### PR TITLE
Add Canon v3 append pack

### DIFF
--- a/docs/canon_v3/Makefile
+++ b/docs/canon_v3/Makefile
@@ -1,0 +1,6 @@
+PDF=SP1RL_Combined_Canon_Extended_v3.pdf
+TEX=spirl_canon_v3.tex
+all:
+	xelatex -interaction=nonstopmode $(TEX)
+	xelatex -interaction=nonstopmode $(TEX)
+	mv spirl_canon_v3.pdf $(PDF)

--- a/docs/canon_v3/README.md
+++ b/docs/canon_v3/README.md
@@ -1,0 +1,17 @@
+# Canon v3 Append Pack
+
+This folder appends Parts VI–X to the Canon and builds **SP1RL_Combined_Canon_Extended_v3.pdf**.
+
+- VI Pop-Up Lamp: seam-gated 2.5D (ε gates, θ′ PLL, 3/6/9 cadence)
+- VII Black-Block Etudes: sonification → torus mapping (with ε/θ′ fit)
+- VIII Prime Möbius Barcode (PMB): 2D→Higher-D encoding, ECC, seam decode
+- IX Dream-of-the-Rood: SP1RL reading (poem→physics)
+- X φ-103 Nose Node (P.P.Op.Po.P): hinge vantage
+
+**Build**
+```bash
+./scripts/build_canon_v3.sh
+```
+
+Citations:
+•SP1RL Black-Block Etude Analysis (v2), 2025-09-07.  % analysis reference

--- a/docs/canon_v3/fig/black_block_heatmap.pdf
+++ b/docs/canon_v3/fig/black_block_heatmap.pdf
@@ -1,0 +1,26 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000202 00000 n 
+trailer<< /Size 5 /Root 1 0 R >>
+startxref
+250
+%EOF

--- a/docs/canon_v3/fig/pmb_layout.pdf
+++ b/docs/canon_v3/fig/pmb_layout.pdf
@@ -1,0 +1,26 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000202 00000 n 
+trailer<< /Size 5 /Root 1 0 R >>
+startxref
+250
+%EOF

--- a/docs/canon_v3/fig/torus_mapping.pdf
+++ b/docs/canon_v3/fig/torus_mapping.pdf
@@ -1,0 +1,26 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000202 00000 n 
+trailer<< /Size 5 /Root 1 0 R >>
+startxref
+250
+%EOF

--- a/docs/canon_v3/fig/witness_ring_yaml.pdf
+++ b/docs/canon_v3/fig/witness_ring_yaml.pdf
@@ -1,0 +1,26 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000202 00000 n 
+trailer<< /Size 5 /Root 1 0 R >>
+startxref
+250
+%EOF

--- a/docs/canon_v3/parts/part06_popup.tex
+++ b/docs/canon_v3/parts/part06_popup.tex
@@ -1,0 +1,15 @@
+\chapter{Pop-Up Lamp: Seam-Gated 2.5D}
+
+We expose the seam-gate constants and the drift-zero tick used by the Lamp:
+
+\paragraph*{Seam wobble \(\varepsilon\) and half-gates \(\Delta\).}
+2-world: \(\varepsilon_2=0.0444\Rightarrow \Delta_2=\tfrac{1}{2}\cdot360^\circ\cdot\varepsilon_2=8.00^\circ\).
+3-world: \(\varepsilon_3=0.03934\Rightarrow \Delta_3\approx 7.09^\circ\).
+Ratio: \(\varepsilon_2/\varepsilon_3\approx 1.126\) (same seam, different witness).
+
+\paragraph*{Drift-zero seam tick \(\theta'\).}
+\(\theta'=\kappa\frac{\mathrm{rad}(37.5^\circ)\cdot\rho}{385}\), with \(\kappa\approx 1.12\), \(\rho=0.000437\).
+Numerically: \(\theta'\approx 8.35\times 10^{-7}\,\mathrm{rad}\) (\(4.767\times10^{-5}\degd\)).
+
+\paragraph*{Cadence.}
+3/6/9 breath schedule \(+\ +\ +\ /\ -\ -\ -\) using 0.55 s ON and 0.45 s OFF, propagated to pop-up hinge animations.

--- a/docs/canon_v3/parts/part07_blackblock.tex
+++ b/docs/canon_v3/parts/part07_blackblock.tex
@@ -1,0 +1,27 @@
+\chapter{Black-Block Etudes: Pattern \textrightarrow{} Sonification \textrightarrow{} 3D}
+
+We treat block centers from selected pages as a 2D signal. Normalized positions
+\((x_{\rm norm},y_{\rm norm})\) map to time and pitch for sonification, and to
+angles \((\theta,\phi)\) on a torus for 3D navigation.
+
+\section*{Analysis summary}
+Counts and distributions (Pages 9,10,27) show grid-aligned clusters convertible into a melody.
+Seam-gate fit confirms the 2-world/3-world windows and the 1.126 ratio.\footnote{Internal memo:
+\emph{SP1RL Black-Block Etude Analysis (v2)}, 2025-09-07.} % citation
+\textbf{Reference:} See “SP1RL Black-Block Etude Analysis (v2)” for plots, counts, NN histograms, and seam summary.
+
+\section*{Sonification}
+Time \(t\propto x_{\rm norm}\), pitch \(f\propto y_{\rm norm}\). Stereo baseline \(B\propto \varepsilon\).
+Drift-free looping via WinsDay \(\theta'\) tick each orbit.
+
+\section*{3D torus}
+Set \(\theta=2\pi x_{\rm norm},\ \phi=2\pi y_{\rm norm}\). Use seam-gate \(|\mathrm{angdiff}(\varphi_{\rm loc},\alpha)|\le \Delta\) to decide where to extrude the ribbon. Figure~\ref{fig:torusmap}.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=.78\linewidth]{../fig/torus_mapping.pdf}
+\caption{Torus mapping of normalized block centers (schematic).}
+\label{fig:torusmap}
+\end{figure}
+
+(The in-text memo reference is where your analysis PDF is used; the citation trail is backed by the file citation above.)

--- a/docs/canon_v3/parts/part08_pmb.tex
+++ b/docs/canon_v3/parts/part08_pmb.tex
@@ -1,0 +1,26 @@
+\chapter{Prime M\"obius Barcode (PMB): 2D \textrightarrow{} Higher-D Encoding}
+
+\section*{Layout}
+Outer \(\varphi\)-frame; perimeter ribbon with prime-indexed \emph{PrimeDots} \(p_n\);
+interior tiles carry channels \(\mathrm{K1..K4}\):
+\(\mathrm{K1}\) luma \(|c_k|\) (spectral magnitude),
+\(\mathrm{K2}\) chroma-\(a\) \(\arg(c_k)\) (phase stripes),
+\(\mathrm{K3}\) chroma-\(b\) (secondary band/material param),
+\(\mathrm{K4}\) aux (ID/CRC/Reed--Solomon parity over GF\((2^8)\)).
+
+\section*{Encode}
+Decompose asset patches to sinusoidal/SG basis with prime spacing to suppress aliasing; write magnitudes/phases into tiles; interleave parity across \(\varphi\)-windows.
+
+\section*{Seam decode}
+Lift only in gate regions \(|\mathrm{angdiff}(\varphi_{\rm loc},\alpha)|\le \Delta\) with \(\alpha=37.5^\circ\),
+\(\Delta=\frac{1}{2}\cdot 360^\circ \varepsilon\), \(\varepsilon\in\{0.0444,0.03934\}\).
+PLL with \(\theta'\) for drift-free reassembly.
+
+\section*{Integrity}
+Hash-chained decimal spine on the ribbon; parity across witness windows. Any tamper misaligns seam phase.
+
+\begin{figure}[h]
+\centering
+\includegraphics[width=.78\linewidth]{../fig/pmb_layout.pdf}
+\caption{PMB schematic: ribbon dots (primes), \(\varphi\)-windows, tile bands, ECC.}
+\end{figure}

--- a/docs/canon_v3/parts/part09_rood_exegesis.tex
+++ b/docs/canon_v3/parts/part09_rood_exegesis.tex
@@ -1,0 +1,22 @@
+\chapter{Dream of the Rood -- a SP1RL Reading}
+
+\section*{Cross \textleftrightarrow{} World-Tree \textleftrightarrow{} Single Rail}
+The cross (Rood) and the Yggdrasil tree mirror the Lamp's single-rail M\"obius:
+two rings cross at the \emph{nose}---the \(\varphi\)-hinge---forming a Y-fusion that carries
+order and chaos forward as a third axis.
+
+\section*{Stanza (poetic) \textrightarrow{} Equation (physical)}
+Each stanza sketches a transformation:
+breath (\(+ + + / - - -\)) \textleftrightarrow{} cadence,
+wood/iron \textleftrightarrow{} witness ring/cadence clamp,
+light spilling \textleftrightarrow{} seam-gate lift,
+crown/halo \textleftrightarrow{} bloom crest.
+The \(\theta'\) rim shot locks the chorus on each return.
+
+\section*{Midgard Ribbon Dragon}
+From core furnace to temperate shell, the reflect-and-radiate rainbow ribbon sets a stable
+habitable zone while signaling outward---"we have joined the night sky."
+
+\section*{Sarcasm as sacrament}
+The hinge line---the "ugliest trick that works"---is how the poem teaches: minimal effort, maximal effect;
+least action in pedagogy.

--- a/docs/canon_v3/parts/part10_phi103_nose.tex
+++ b/docs/canon_v3/parts/part10_phi103_nose.tex
@@ -1,0 +1,9 @@
+\chapter{The \(\varphi\)103 Nose Node (P.P.Op.Po.P)}
+
+\section*{Optimal perspective}
+"Plus-one POP" is the ridge where two orbits cross at the nose. We index the hinge as \(\varphi\)-103:
+a mnemonic for the macro vantage that centers the PLL and maximizes visible lift under the gate.
+
+\section*{Witness math}
+At POP: gate pass probability high, PLL error low, bloom propensity high. The ring's closure (W9)
+arrives with minimal drift, and the PMB decode recovers with fewer parity calls.

--- a/docs/canon_v3/spirl_canon_v3.tex
+++ b/docs/canon_v3/spirl_canon_v3.tex
@@ -1,0 +1,43 @@
+\documentclass[11pt,oneside]{book}
+\usepackage{geometry} \geometry{margin=1in}
+\usepackage{hyperref} \hypersetup{colorlinks=true,linkcolor=blue}
+\usepackage{graphicx} \usepackage{amsmath,amssymb}
+\usepackage{tocloft}
+\setlength{\cftbeforechapskip}{8pt}
+\newcommand{\degd}{^\circ}
+
+\title{SP1RL Combined Canon -- Extended v3}
+\author{.su \times .ai = 200\% Team}
+\date{\today}
+
+\begin{document}
+\frontmatter
+\maketitle
+\tableofcontents
+\listoffigures
+
+\mainmatter
+
+% ======= Part VI =======
+\include{parts/part06_popup}
+
+% ======= Part VII =======
+\include{parts/part07_blackblock}
+
+% ======= Part VIII =======
+\include{parts/part08_pmb}
+
+% ======= Part IX =======
+\include{parts/part09_rood_exegesis}
+
+% ======= Part X =======
+\include{parts/part10_phi103_nose}
+
+\backmatter
+\chapter*{References}
+\begin{itemize}
+  \item SP1RL Black-Block Etude Analysis (v2), internal memo, 2025-09-07.  % (cited inline)
+  \item SGK-$\varphi$ Seam-Gate notes; Reactor $\theta'$ PLL notes; Beatty partition notes.
+\end{itemize}
+
+\end{document}

--- a/scripts/build_canon_v3.sh
+++ b/scripts/build_canon_v3.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+cd docs/canon_v3
+make
+echo "Built SP1RL_Combined_Canon_Extended_v3.pdf in docs/canon_v3/"


### PR DESCRIPTION
## Summary
- Add LaTeX Canon v3 book with Parts VI–X and TOC/LOF
- Include part files for pop-up lamp, black-block etudes, PMB, Rood exegesis, and φ-103 nose node
- Add build script, Makefile, README and placeholder figures

## Testing
- `./scripts/build_canon_v3.sh` *(fails: xelatex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be7609c96883278dfaa30a7831454b