### PR TITLE
feat(core): expand phi constants and rainbow piano mapping

### DIFF
--- a/spirl-canon/packages/core/src/phi.js
+++ b/spirl-canon/packages/core/src/phi.js
@@ -7,8 +7,10 @@ export const EPS_3WORLD = 0.03934;  // Δ3 ≈ 7.09°
 export const DELTA_2_DEG = 180 * EPS_2WORLD;
 export const DELTA_3_DEG = 180 * EPS_3WORLD;
 
-export function thetaPrime(kappa = 1.12, rho = 0.000437) {
-  const alphaRad = ALPHA_DEG * Math.PI / 180;
-  return kappa * (alphaRad * rho) / 385; // ≈ 8.3e-7 rad
+export const RHO = 0.000437;
+
+export function thetaPrime(kappa = 1.12, rho = RHO) {
+  const alphaRad = (ALPHA_DEG * Math.PI) / 180;
+  return (kappa * (alphaRad * rho)) / 385; // ≈ 8.3e-7 rad
 }
 export function phiTilt(k) { return (k * 137.5) % 360; }

--- a/spirl-canon/packages/core/src/phi.ts
+++ b/spirl-canon/packages/core/src/phi.ts
@@ -7,8 +7,15 @@ export const EPS_3WORLD = 0.03934;  // Δ3 ≈ 7.09°
 export const DELTA_2_DEG = 180 * EPS_2WORLD;
 export const DELTA_3_DEG = 180 * EPS_3WORLD;
 
-export function thetaPrime(kappa = 1.12, rho = 0.000437) {
-  const alphaRad = ALPHA_DEG * Math.PI / 180;
-  return kappa * (alphaRad * rho) / 385; // ≈ 8.3e-7 rad
+// Rood wobble ratio used by thetaPrime; exported for receipts/tests.
+export const RHO = 0.000437;
+
+export function thetaPrime(kappa = 1.12, rho = RHO) {
+  const alphaRad = (ALPHA_DEG * Math.PI) / 180;
+  return (kappa * (alphaRad * rho)) / 385; // ≈ 8.3e-7 rad
 }
-export function phiTilt(k: number) { return (k * 137.5) % 360; }
+
+// Golden-angle tilt index in degrees.
+export function phiTilt(k: number) {
+  return (k * 137.5) % 360;
+}

--- a/spirl-canon/packages/core/src/rainbowPiano.ts
+++ b/spirl-canon/packages/core/src/rainbowPiano.ts
@@ -1,9 +1,39 @@
 export type Palette = "O"|"B"|"K"|"R"|"G"|"Au"|"Si"|"BW";
+// Softmax helper used to bias palettes toward a set of weights.
 export function colorWeights(A: number, bias: Record<Palette, number>) {
   const keys = Object.keys(bias) as Palette[];
-  const exps = keys.map(k => Math.exp((bias[k] || 0) * A));
-  const sum = exps.reduce((a,b)=>a+b,0) || 1;
+  const exps = keys.map((k) => Math.exp((bias[k] || 0) * A));
+  const sum = exps.reduce((a, b) => a + b, 0) || 1;
   const out: Record<string, number> = {};
-  keys.forEach((k,i)=> out[k] = exps[i] / sum);
+  keys.forEach((k, i) => (out[k] = exps[i] / sum));
   return out;
+}
+
+const NOTE_TO_PALETTE: Palette[] = [
+  "O", "B", "K", "R", "G", "Au", "Si", "BW",
+  "O", "B", "K", "R"
+];
+
+/**
+ * Map a MIDI note/velocity to an HSV triple.
+ * The hue derives from the palette weight selected by the note class,
+ * while velocity modulates saturation/value.
+ */
+export function noteToColor(
+  note: number,
+  vel: number,
+  bias: Record<Palette, number>
+) {
+  const cls = NOTE_TO_PALETTE[note % 12];
+  const weights = colorWeights(vel, bias);
+  const hue = weights[cls] || 0;
+  const saturation = Math.max(0, Math.min(1, vel));
+  const value = saturation;
+  return { palette: cls, hue, saturation, value, weights };
+}
+
+/** Determine a lane index for radial onsets. */
+export function onsetToLane(time: number, breathPhase: number) {
+  const phase = breathPhase || 1;
+  return Math.floor((time / phase) % 6); // 6 lanes for stub
 }


### PR DESCRIPTION
## Summary
- expose RHO constant and default thetaPrime to use it
- add note-to-color and onset lane helpers for Rainbow Piano mapping

## Testing
- `RUN_ONLINE=1 pnpm test` *(fails: vitest: not found)*
- `RUN_ONLINE=1 npx vitest run` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb6d12f208327bb5fe49d961979a6