### PR TITLE
feat: launch mobile portal PWA with PMB workflow

### DIFF
--- a/spirl-canon/apps/portal/public/modules.json
+++ b/spirl-canon/apps/portal/public/modules.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "oscillator",
+    "name": "Golden Oscillator",
+    "description": "Generates φ-locked tone streams.",
+    "inputs": [
+      { "name": "frequency", "type": "number", "default": 432 },
+      { "name": "waveform", "type": "string", "default": "sine" }
+    ]
+  },
+  {
+    "id": "lattice",
+    "name": "Lattice Stitch",
+    "description": "Sequencer weaving beads into φ grids.",
+    "inputs": [
+      { "name": "stages", "type": "number", "default": 3 },
+      { "name": "pattern", "type": "string", "default": "1-1-2-3-5" }
+    ]
+  },
+  {
+    "id": "render",
+    "name": "Render Bloom",
+    "description": "Renders the bundle locally using WASM shells.",
+    "inputs": [
+      { "name": "quality", "type": "number", "default": 0.8 },
+      { "name": "format", "type": "string", "default": "webm" }
+    ]
+  }
+]

--- a/spirl-canon/apps/portal/public/sw.js
+++ b/spirl-canon/apps/portal/public/sw.js
@@ -4,6 +4,7 @@ self.addEventListener('activate', e => { self.clients.claim(); });
 const PRECACHE = [
   '/', '/manifest.webmanifest',
   '/icons/icon-192.png', '/icons/icon-512.png',
+  '/modules.json',
 ];
 
 self.addEventListener('fetch', (event) => {

--- a/spirl-canon/apps/portal/src/app/(routes)/index.tsx
+++ b/spirl-canon/apps/portal/src/app/(routes)/index.tsx
@@ -1,13 +1,41 @@
 import React from 'react';
 import Link from 'next/link';
+
+const steps = [
+  'Compose beads with the Registry builder.',
+  'Seal the φ-pinch prelude and confirm the punch window.',
+  'Encode to a PMB Möbius Rainbow and save the PNG.',
+  'Scan the PMB (camera or upload) to restore the recipe.',
+  'Run locally or bundle for Promote → GitHub Pages.',
+];
+
 export default function Home() {
   return (
-    <main>
-      <h1>SP1RL Portal</h1>
-      <nav>
-        <Link href="/encode">Encode</Link>
-        <Link href="/scan">Scan</Link>
+    <main className="home">
+      <header>
+        <h1>SP1RL Portal</h1>
+        <p>
+          Mobile-first PWA for composing φ recipes, rendering PMB Möbius Rainbow barcodes, and
+          operating offline bundles.
+        </p>
+      </header>
+      <nav className="cta">
+        <Link href="/encode" className="btn">
+          Compose &amp; Encode
+        </Link>
+        <Link href="/scan" className="btn secondary">
+          Scan PMB
+        </Link>
       </nav>
+      <section className="guide">
+        <h2>Rail Quickstart</h2>
+        <ol>
+          {steps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+        <p className="meta">Install from your browser menu to pin the portal on your phone.</p>
+      </section>
     </main>
   );
 }

--- a/spirl-canon/apps/portal/src/app/bundle/[id]/page.tsx
+++ b/spirl-canon/apps/portal/src/app/bundle/[id]/page.tsx
@@ -1,5 +1,42 @@
+'use client';
+
 import React from 'react';
 import OperatorPanel from '../../../components/OperatorPanel';
-export default function BundlePage(){
-  return <OperatorPanel />;
+import { schedule, type ScheduledRecipe } from '../../../lib/orchestrator';
+
+export default function BundlePage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const [recipe, setRecipe] = React.useState<ScheduledRecipe | null>(null);
+  const [error, setError] = React.useState<string>('');
+
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch(`/bundles/${id}.json`)
+      .then(async (response) => {
+        if (!response.ok) throw new Error('Bundle not found');
+        const data = await response.json();
+        if (cancelled) return;
+        const scheduled = schedule(data);
+        setRecipe(scheduled);
+      })
+      .catch((err: any) => {
+        if (!cancelled) {
+          setError(err.message || 'Unable to load bundle.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <main className="page bundle">
+      <header>
+        <h1>Bundle · {id}</h1>
+        <p>Offline operator shell</p>
+      </header>
+      {recipe && <OperatorPanel recipe={recipe} />}
+      {error && <p className="error">{error}</p>}
+    </main>
+  );
 }

--- a/spirl-canon/apps/portal/src/app/encode/page.tsx
+++ b/spirl-canon/apps/portal/src/app/encode/page.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import Builder from '../../components/Builder';
-export default function EncodePage(){
-  return <Builder />;
+
+export default function EncodePage() {
+  return (
+    <main className="page encode">
+      <Builder />
+    </main>
+  );
 }

--- a/spirl-canon/apps/portal/src/app/layout.tsx
+++ b/spirl-canon/apps/portal/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import '../styles/globals.css';
+import React from 'react';
+import ServiceWorkerRegister from '../components/ServiceWorkerRegister';
+
+export const metadata = {
+  title: 'SP1RL Portal',
+  description: 'Compose φ recipes, encode to PMB, and run offline shells.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ServiceWorkerRegister />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/spirl-canon/apps/portal/src/app/scan/page.tsx
+++ b/spirl-canon/apps/portal/src/app/scan/page.tsx
@@ -1,5 +1,34 @@
+'use client';
+
 import React from 'react';
 import PMBScanner from '../../components/PMBScanner';
-export default function ScanPage(){
-  return <PMBScanner onLoad={()=>{}} />;
+import OperatorPanel from '../../components/OperatorPanel';
+import { schedule, type ScheduledRecipe } from '../../lib/orchestrator';
+import type { PMBPayload } from '../../../../packages/core/src/pmbAssign';
+
+export default function ScanPage() {
+  const [recipe, setRecipe] = React.useState<ScheduledRecipe | null>(null);
+
+  const handleLoad = (payload: PMBPayload) => {
+    const scheduled = schedule({
+      id: payload.id,
+      name: payload.name,
+      beads: payload.beads,
+      punchWindow: payload.punch,
+    });
+    setRecipe(scheduled);
+  };
+
+  return (
+    <main className="page scan">
+      <PMBScanner onLoad={handleLoad} />
+      {recipe && (
+        <section className="results">
+          <h2>Decoded Recipe</h2>
+          <pre>{JSON.stringify(recipe, null, 2)}</pre>
+          <OperatorPanel recipe={recipe} />
+        </section>
+      )}
+    </main>
+  );
 }

--- a/spirl-canon/apps/portal/src/components/Builder.tsx
+++ b/spirl-canon/apps/portal/src/components/Builder.tsx
@@ -1,8 +1,165 @@
+'use client';
+
 import React from 'react';
-import { schedule, Recipe } from '../lib/orchestrator';
+import { schedule, type Bead, type ScheduledRecipe } from '../lib/orchestrator';
 import PMBEncoder from './PMBEncoder';
+import OperatorPanel from './OperatorPanel';
+import { queryModules, type Module } from '../lib/registry';
+
+const DEFAULT_PUNCH = { tStartSec: 616, tEndSec: 677 };
 
 export default function Builder() {
-  const recipe: Recipe = schedule({ id: 'r1', name: 'demo', beads: [], punchWindow: { tStartSec: 616, tEndSec: 677 } });
-  return <div><PMBEncoder recipe={recipe} /></div>;
+  const [modules, setModules] = React.useState<Module[]>([]);
+  const [search, setSearch] = React.useState('');
+  const [beads, setBeads] = React.useState<Bead[]>([]);
+  const [name, setName] = React.useState('Möbius Prelude');
+  const [recipeId, setRecipeId] = React.useState(() =>
+    `bundle-${new Date().toISOString().replace(/[:T]/g, '-').slice(0, 19)}`
+  );
+  const [scheduled, setScheduled] = React.useState<ScheduledRecipe | null>(null);
+  const [runLogs, setRunLogs] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    let mounted = true;
+    queryModules(search).then((rows) => {
+      if (mounted) setModules(rows);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [search]);
+
+  React.useEffect(() => {
+    const recipe = schedule({ id: recipeId, name, beads, punchWindow: DEFAULT_PUNCH });
+    setScheduled(recipe);
+    setRunLogs([]);
+  }, [recipeId, name, beads]);
+
+  const addBead = (module: Module) => {
+    const inputs: Record<string, any> = {};
+    module.inputs.forEach((input) => {
+      inputs[input.name] = input.default ?? '';
+    });
+    setBeads((prev) => [
+      ...prev,
+      { id: `${module.id}-${prev.length + 1}`, moduleId: module.id, inputs },
+    ]);
+  };
+
+  const updateBead = (index: number, key: string, value: any) => {
+    setBeads((prev) => {
+      const next = prev.slice();
+      next[index] = { ...next[index], inputs: { ...next[index].inputs, [key]: value } };
+      return next;
+    });
+  };
+
+  const removeBead = (index: number) => {
+    setBeads((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const exportRecipe = () => {
+    if (!scheduled) return;
+    const blob = new Blob([JSON.stringify(scheduled, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${scheduled.id || 'recipe'}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleRunComplete = (logs: string[]) => {
+    setRunLogs(logs);
+  };
+
+  return (
+    <div className="builder">
+      <section className="panel modules">
+        <header>
+          <h2>Registry</h2>
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search modules"
+            aria-label="Search modules"
+          />
+        </header>
+        <ul>
+          {modules.map((module) => (
+            <li key={module.id}>
+              <div>
+                <strong>{module.name}</strong>
+                <p>{module.description}</p>
+              </div>
+              <button type="button" onClick={() => addBead(module)}>
+                Add
+              </button>
+            </li>
+          ))}
+          {modules.length === 0 && <li className="empty">Loading registry…</li>}
+        </ul>
+      </section>
+      <section className="panel beads">
+        <header>
+          <h2>Recipe</h2>
+          <label>
+            Name
+            <input value={name} onChange={(event) => setName(event.target.value)} />
+          </label>
+          <label>
+            Recipe ID
+            <input value={recipeId} onChange={(event) => setRecipeId(event.target.value)} />
+          </label>
+          <button type="button" onClick={exportRecipe} className="btn secondary">
+            Export Recipe JSON
+          </button>
+        </header>
+        <ol>
+          {beads.map((bead, index) => (
+            <li key={bead.id}>
+              <div className="bead-header">
+                <span>
+                  {index + 1}. {bead.moduleId}
+                </span>
+                <button type="button" onClick={() => removeBead(index)}>
+                  Remove
+                </button>
+              </div>
+              <div className="inputs">
+                {Object.entries(bead.inputs).map(([key, value]) => (
+                  <label key={key}>
+                    {key}
+                    <input
+                      value={String(value)}
+                      onChange={(event) => updateBead(index, key, event.target.value)}
+                    />
+                  </label>
+                ))}
+              </div>
+            </li>
+          ))}
+          {beads.length === 0 && <li className="empty">Add modules to weave beads.</li>}
+        </ol>
+      </section>
+      {scheduled && (
+        <section className="panel preview">
+          <PMBEncoder recipe={scheduled} />
+          <OperatorPanel recipe={scheduled} onRunComplete={handleRunComplete} />
+          {runLogs.length > 0 && (
+            <aside className="logs">
+              <h3>Operator Receipts</h3>
+              <ul>
+                {runLogs.map((line, index) => (
+                  <li key={`${line}-${index}`}>{line}</li>
+                ))}
+              </ul>
+            </aside>
+          )}
+        </section>
+      )}
+    </div>
+  );
 }

--- a/spirl-canon/apps/portal/src/components/OperatorPanel.tsx
+++ b/spirl-canon/apps/portal/src/components/OperatorPanel.tsx
@@ -1,4 +1,52 @@
+'use client';
+
 import React from 'react';
-export default function OperatorPanel() {
-  return <div>Operator Panel</div>;
+import type { ScheduledRecipe } from '../lib/orchestrator';
+import { run, type OperatorLog } from '../lib/runtime';
+
+export default function OperatorPanel({
+  recipe,
+  onRunComplete,
+}: {
+  recipe: ScheduledRecipe;
+  onRunComplete?: (logs: string[]) => void;
+}) {
+  const [logs, setLogs] = React.useState<OperatorLog[]>([]);
+  const [status, setStatus] = React.useState<'idle' | 'running' | 'done'>('idle');
+  const online = typeof navigator === 'undefined' ? true : navigator.onLine;
+
+  const execute = async () => {
+    setStatus('running');
+    const results = await run(recipe);
+    setLogs(results);
+    setStatus('done');
+    onRunComplete?.(results.map((log) => formatLog(log)));
+  };
+
+  React.useEffect(() => {
+    setStatus('idle');
+    setLogs([]);
+  }, [recipe]);
+
+  return (
+    <section className="operator">
+      <header>
+        <h2>Operator Shell</h2>
+        <p>{online ? 'Offline ready · cache primed' : 'Offline · running from cache'}</p>
+      </header>
+      <button type="button" className="btn" onClick={execute} disabled={status === 'running'}>
+        {status === 'running' ? 'Running…' : 'Run Recipe'}
+      </button>
+      <div className="terminal" role="log" aria-live="polite">
+        {logs.length === 0 && <p>φ-pinch prelude awaits. Tap run to execute locally.</p>}
+        {logs.map((log) => (
+          <p key={`${log.moduleId}-${log.at}`}>{formatLog(log)}</p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function formatLog(log: OperatorLog) {
+  return `t+${log.at.toFixed(2)}s · ${log.moduleId} → ${log.detail}`;
 }

--- a/spirl-canon/apps/portal/src/components/PMBEncoder.tsx
+++ b/spirl-canon/apps/portal/src/components/PMBEncoder.tsx
@@ -1,13 +1,49 @@
-import React from 'react';
-import { mathReceipt } from '../../../packages/core/src/receipts';
-import { recipeToPMB } from '../../../packages/core/src/pmbAssign';
-import { encodePMB } from '../lib/pmb/encode';
+'use client';
 
-export default function PMBEncoder({ recipe }: { recipe: any }) {
+import React from 'react';
+import { mathReceipt } from '../../../../packages/core/src/receipts';
+import { recipeToPMB } from '../../../../packages/core/src/pmbAssign';
+import { drawPMB, exportPMBPNG } from '../lib/pmb/encode';
+import type { ScheduledRecipe } from '../lib/orchestrator';
+
+export default function PMBEncoder({ recipe }: { recipe: ScheduledRecipe }) {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
+  const [downloadUrl, setDownloadUrl] = React.useState<string>('');
+  const [receipt, setReceipt] = React.useState<string>('');
+  const [payloadId, setPayloadId] = React.useState<string>('');
+
   React.useEffect(() => {
-    const receipt = mathReceipt();
-    const payload = recipeToPMB(recipe, receipt);
-    encodePMB(payload); // drawing skipped in tests
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const receiptText = recipe.receipt ?? mathReceipt();
+    const payload = recipeToPMB(recipe, receiptText);
+    drawPMB(canvas, payload);
+    const blob = exportPMBPNG(canvas, payload);
+    const url = URL.createObjectURL(blob);
+    setDownloadUrl(url);
+    setReceipt(receiptText);
+    setPayloadId(payload.id);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
   }, [recipe]);
-  return <div>PMB Encoder</div>;
+
+  return (
+    <section className="pmb-encoder">
+      <header>
+        <h2>PMB Möbius Rainbow</h2>
+        <p>Deterministic digest · {payloadId}</p>
+        <p className="receipt">{receipt}</p>
+      </header>
+      <canvas ref={canvasRef} width={1200} height={1200} aria-label="PMB barcode" />
+      <div className="actions">
+        {downloadUrl && (
+          <a href={downloadUrl} download={`${payloadId || 'recipe'}.png`} className="btn">
+            Download PMB PNG
+          </a>
+        )}
+        <p className="hint">Save to Files/Photos. The payload rides inside the PNG footer.</p>
+      </div>
+    </section>
+  );
 }

--- a/spirl-canon/apps/portal/src/components/PMBScanner.tsx
+++ b/spirl-canon/apps/portal/src/components/PMBScanner.tsx
@@ -1,13 +1,96 @@
+'use client';
+
 import React from 'react';
 import { decodePMB } from '../lib/pmb/decode';
+import type { PMBPayload } from '../../../../packages/core/src/pmbAssign';
 
-export default function PMBScanner({ onLoad }: { onLoad: (p: any) => void }) {
-  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
-    if (!f) return;
-    const buf = Buffer.from(await f.arrayBuffer());
-    const p = decodePMB(buf);
-    onLoad(p);
+export default function PMBScanner({ onLoad }: { onLoad: (payload: PMBPayload) => void }) {
+  const videoRef = React.useRef<HTMLVideoElement | null>(null);
+  const [error, setError] = React.useState<string>('');
+
+  React.useEffect(() => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setError('Camera unavailable in this environment. Use the upload field.');
+      return () => {};
+    }
+    let active = true;
+    let currentStream: MediaStream | null = null;
+    navigator.mediaDevices
+      .getUserMedia({ video: { facingMode: 'environment' } })
+      .then((mediaStream) => {
+        if (!active) return;
+        currentStream = mediaStream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = mediaStream;
+          videoRef.current.play().catch(() => {
+            setError('Unable to start camera preview.');
+          });
+        }
+      })
+      .catch(() => {
+        setError('Camera permissions denied. Use file upload instead.');
+      });
+    return () => {
+      active = false;
+      mediaStreamStop(currentStream);
+    };
+  }, []);
+
+  const handleFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const payload = await decodePMB(file);
+      onLoad(payload);
+      setError('');
+    } catch (err: any) {
+      setError(err.message || 'Unable to decode PMB.');
+    }
   };
-  return <input type="file" accept="image/*" onChange={handleFile} />;
+
+  const handleCapture = async () => {
+    if (!videoRef.current) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = videoRef.current.videoWidth;
+    canvas.height = videoRef.current.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
+    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob((b) => resolve(b), 'image/png'));
+    if (!blob) {
+      setError('Failed to capture frame from camera.');
+      return;
+    }
+    try {
+      const payload = await decodePMB(blob);
+      onLoad(payload);
+      setError('');
+    } catch (err: any) {
+      setError('Frame captured but PMB payload not found. Try uploading the exported PNG.');
+    }
+  };
+
+  return (
+    <section className="scanner">
+      <header>
+        <h2>Scan PMB</h2>
+        <p>Point at a Möbius Rainbow barcode or upload the exported PNG.</p>
+      </header>
+      <video ref={videoRef} playsInline muted className="preview" />
+      <div className="actions">
+        <button type="button" className="btn" onClick={handleCapture}>
+          Capture Frame
+        </button>
+        <label className="btn file">
+          Upload / Camera
+          <input type="file" accept="image/*" capture="environment" onChange={handleFile} />
+        </label>
+      </div>
+      {error && <p className="error">{error}</p>}
+    </section>
+  );
+}
+
+function mediaStreamStop(stream: MediaStream | null) {
+  stream?.getTracks().forEach((track) => track.stop());
 }

--- a/spirl-canon/apps/portal/src/components/ServiceWorkerRegister.tsx
+++ b/spirl-canon/apps/portal/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+
+export default function ServiceWorkerRegister() {
+  React.useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch(() => {
+          // noop - registration failures are non-fatal
+        });
+    }
+  }, []);
+  return null;
+}

--- a/spirl-canon/apps/portal/src/lib/orchestrator.ts
+++ b/spirl-canon/apps/portal/src/lib/orchestrator.ts
@@ -1,9 +1,41 @@
-export type Bead = { id: string; moduleId: string; inputs: any; tSec?: number };
-export type Recipe = { id: string; name: string; beads: Bead[]; punchWindow?: { tStartSec: number; tEndSec: number } };
+import { mathReceipt } from '../../../../packages/core/src/receipts';
 
-export function schedule(recipe: Recipe) {
-  let t = 0;
-  const beads = recipe.beads.map(b => ({ ...b, tSec: ++t }));
-  const punchWindow = recipe.punchWindow || { tStartSec: 616, tEndSec: 677 };
-  return { ...recipe, beads, punchWindow };
+export type Bead = { id: string; moduleId: string; inputs: Record<string, any>; tSec?: number };
+export type Recipe = {
+  id: string;
+  name: string;
+  beads: Bead[];
+  punchWindow?: { tStartSec: number; tEndSec: number };
+  receipt?: string;
+};
+
+export type ScheduledRecipe = Required<Omit<Recipe, 'receipt'>> & { receipt: string };
+
+const DEFAULT_PUNCH = { tStartSec: 616, tEndSec: 677 };
+const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+
+export function schedule(recipe: Recipe): ScheduledRecipe {
+  const punchWindow = recipe.punchWindow ?? DEFAULT_PUNCH;
+  const beads = recipe.beads.slice();
+  const intervals = goldenIntervals(beads.length);
+  const preludeDuration = intervals.reduce((sum, value) => sum + value, 0);
+  const start = punchWindow.tStartSec - preludeDuration;
+  let cursor = start;
+  const scheduled = beads.map((bead, index) => {
+    cursor += intervals[index];
+    return { ...bead, tSec: Number(cursor.toFixed(3)) };
+  });
+  const receipt = recipe.receipt ?? mathReceipt();
+  return { ...recipe, beads: scheduled, punchWindow, receipt } as ScheduledRecipe;
+}
+
+function goldenIntervals(count: number): number[] {
+  if (count === 0) return [];
+  const pinchSpan = 144; // seconds of φ-pinch ramp before the punch window
+  const weights: number[] = [];
+  for (let i = 0; i < count; i += 1) {
+    weights.push(Math.pow(GOLDEN_RATIO, i));
+  }
+  const weightSum = weights.reduce((sum, value) => sum + value, 0);
+  return weights.map((value) => (pinchSpan * value) / weightSum);
 }

--- a/spirl-canon/apps/portal/src/lib/pmb/decode.ts
+++ b/spirl-canon/apps/portal/src/lib/pmb/decode.ts
@@ -1,13 +1,92 @@
 import { PMBPayload } from '../../../../packages/core/src/pmbAssign';
 
-export function decodePMB(buf: Buffer): PMBPayload {
-  const txt = buf.toString('utf8');
-  const tag = 'PMB:';
-  const idx = txt.lastIndexOf(tag);
+const PMB_TAG = 'PMB:';
+const GRID_COLS = 48;
+const GRID_ROWS = 48;
+const GRID_CELL = 10;
+const GRID_MARGIN = 48;
+
+function base64Decode(data: string): string {
+  if (typeof atob === 'function') {
+    return decodeURIComponent(escape(atob(data)));
+  }
+  const NodeBuffer = (globalThis as unknown as { Buffer?: { from(data: string, encoding: string): { toString(enc: string): string } } }).Buffer;
+  if (NodeBuffer?.from) {
+    return NodeBuffer.from(data, 'base64').toString('utf8');
+  }
+  throw new Error('No base64 decoder available');
+}
+
+export async function decodePMB(source: Blob | File): Promise<PMBPayload> {
+  const buffer = await source.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  try {
+    return decodePMBBytes(bytes);
+  } catch (error) {
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      const blob = new Blob([bytes], { type: 'image/png' });
+      return decodeFromCanvas(blob);
+    }
+    throw error;
+  }
+}
+
+export function decodePMBBytes(bytes: Uint8Array): PMBPayload {
+  const text = new TextDecoder('latin1').decode(bytes);
+  const idx = text.lastIndexOf(PMB_TAG);
   if (idx >= 0) {
-    const b64 = txt.slice(idx + tag.length);
-    const json = Buffer.from(b64, 'base64').toString('utf8');
+    const raw = text.slice(idx + PMB_TAG.length).replace(/\0+$/, '');
+    const json = base64Decode(raw);
     return JSON.parse(json);
   }
   throw new Error('PMB payload not found');
+}
+
+async function decodeFromCanvas(blob: Blob): Promise<PMBPayload> {
+  const image = await loadImage(blob);
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('PMB payload not found');
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  const lengthHigh = sampleCell(ctx, canvas.width, canvas.height, 0);
+  const lengthLow = sampleCell(ctx, canvas.width, canvas.height, 1);
+  const charCount = (lengthHigh << 8) | lengthLow;
+  if (!charCount) throw new Error('PMB payload not found');
+  const chars: string[] = [];
+  for (let index = 0; index < charCount; index += 1) {
+    const value = sampleCell(ctx, canvas.width, canvas.height, index + 2);
+    chars.push(String.fromCharCode(value));
+  }
+  const base64 = chars.join('');
+  const json = base64Decode(base64);
+  return JSON.parse(json);
+}
+
+function sampleCell(ctx: CanvasRenderingContext2D, width: number, height: number, index: number): number {
+  const col = index % GRID_COLS;
+  const row = Math.floor(index / GRID_COLS);
+  if (row >= GRID_ROWS) return 0;
+  const x = GRID_MARGIN + col * GRID_CELL + GRID_CELL / 2;
+  const y = height - GRID_MARGIN - GRID_ROWS * GRID_CELL + row * GRID_CELL + GRID_CELL / 2;
+  const data = ctx.getImageData(Math.floor(x), Math.floor(y), 1, 1).data;
+  const brightness = (data[0] + data[1] + data[2]) / 3;
+  return Math.max(0, Math.min(255, Math.round(brightness)));
+}
+
+async function loadImage(blob: Blob): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = (error) => {
+      URL.revokeObjectURL(url);
+      reject(error);
+    };
+    img.src = url;
+  });
 }

--- a/spirl-canon/apps/portal/src/lib/pmb/encode.ts
+++ b/spirl-canon/apps/portal/src/lib/pmb/encode.ts
@@ -1,9 +1,134 @@
 import { PMBPayload } from '../../../../packages/core/src/pmbAssign';
+import { phiTicks } from '../../../../packages/core/src/pmbGlyph';
 
-export function encodePMB(payload: PMBPayload): Buffer {
+const PMB_TAG = 'PMB:';
+const GRID_COLS = 48;
+const GRID_ROWS = 48;
+const GRID_CELL = 10;
+const GRID_MARGIN = 48;
+
+function base64Encode(json: string): string {
+  if (typeof btoa === 'function') {
+    return btoa(unescape(encodeURIComponent(json)));
+  }
+  const NodeBuffer = (globalThis as unknown as { Buffer?: { from(data: string, encoding: string): { toString(enc: string): string } } }).Buffer;
+  if (NodeBuffer?.from) {
+    return NodeBuffer.from(json, 'utf8').toString('base64');
+  }
+  throw new Error('No base64 encoder available');
+}
+
+export function payloadToBase64(payload: PMBPayload): string {
   const json = JSON.stringify(payload);
-  const b64 = Buffer.from(json, 'utf8').toString('base64');
-  const prefix = Buffer.from('PNG_STUB');
-  const trailer = Buffer.from('PMB:' + b64);
-  return Buffer.concat([prefix, trailer]);
+  return base64Encode(json);
+}
+
+export function serializePMBPayload(payload: PMBPayload): Uint8Array {
+  const prefix = new TextEncoder().encode('PNG_STUB');
+  const trailer = new TextEncoder().encode(PMB_TAG + payloadToBase64(payload));
+  const bytes = new Uint8Array(prefix.length + trailer.length);
+  bytes.set(prefix, 0);
+  bytes.set(trailer, prefix.length);
+  return bytes;
+}
+
+export function drawPMB(canvas: HTMLCanvasElement, payload: PMBPayload) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  const size = 1200;
+  canvas.width = size;
+  canvas.height = size;
+  ctx.fillStyle = '#0b0f1a';
+  ctx.fillRect(0, 0, size, size);
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const radius = 460;
+  const ticks = phiTicks(144);
+  ticks.forEach((tick, index) => {
+    const angle = (tick.angleDeg * Math.PI) / 180;
+    const xOuter = cx + radius * Math.cos(angle);
+    const yOuter = cy + radius * Math.sin(angle);
+    const innerRadius = tick.emphasis ? radius - 42 : radius - 24;
+    const xInner = cx + innerRadius * Math.cos(angle);
+    const yInner = cy + innerRadius * Math.sin(angle);
+    ctx.strokeStyle = tick.emphasis ? '#3a4b7a' : '#223356';
+    ctx.lineWidth = tick.emphasis ? 4 : 2;
+    ctx.beginPath();
+    ctx.moveTo(xOuter, yOuter);
+    ctx.lineTo(xInner, yInner);
+    ctx.stroke();
+  });
+
+  const base64 = payloadToBase64(payload);
+  const characters = [...base64];
+  const trackRadiusStart = 140;
+  const trackRadiusEnd = radius - 80;
+  const track = trackRadiusEnd - trackRadiusStart;
+
+  characters.forEach((char, index) => {
+    const ratio = index / Math.max(1, characters.length - 1);
+    const radiusAtChar = trackRadiusStart + track * ratio;
+    const turns = 4;
+    const theta = ratio * turns * Math.PI * 2;
+    const hue = (charToValue(char) / 64) * 360;
+    ctx.fillStyle = `hsl(${hue} 80% 58%)`;
+    const x = cx + radiusAtChar * Math.cos(theta);
+    const y = cy + radiusAtChar * Math.sin(theta);
+    ctx.beginPath();
+    ctx.arc(x, y, 6, 0, 2 * Math.PI);
+    ctx.fill();
+  });
+
+  ctx.fillStyle = '#b8c6ff';
+  ctx.font = '20px ui-monospace, Menlo, monospace';
+  ctx.fillText(payload.receipt, cx - 320, size - 60);
+  ctx.fillText(`${payload.name} · ${payload.id}`, cx - 320, size - 30);
+
+  encodeGrid(ctx, size, characters);
+}
+
+function charToValue(char: string): number {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  const idx = alphabet.indexOf(char);
+  return idx >= 0 ? idx : 0;
+}
+
+function encodeGrid(ctx: CanvasRenderingContext2D, size: number, characters: string[]) {
+  const encoded: number[] = [];
+  const length = characters.length;
+  encoded.push((length >> 8) & 0xff);
+  encoded.push(length & 0xff);
+  characters.forEach((char) => {
+    encoded.push(char.charCodeAt(0));
+  });
+  ctx.fillStyle = 'rgba(11, 15, 26, 0.75)';
+  const areaHeight = GRID_ROWS * GRID_CELL;
+  ctx.fillRect(
+    GRID_MARGIN - 8,
+    size - GRID_MARGIN - areaHeight - 8,
+    GRID_COLS * GRID_CELL + 16,
+    areaHeight + 16
+  );
+  encoded.forEach((value, index) => {
+    if (index >= GRID_ROWS * GRID_COLS) return;
+    const col = index % GRID_COLS;
+    const row = Math.floor(index / GRID_COLS);
+    const brightness = Math.round(32 + (value / 255) * 200);
+    ctx.fillStyle = `rgb(${brightness}, ${brightness}, ${brightness})`;
+    const x = GRID_MARGIN + col * GRID_CELL;
+    const y = size - GRID_MARGIN - GRID_ROWS * GRID_CELL + row * GRID_CELL;
+    ctx.fillRect(x, y, GRID_CELL - 2, GRID_CELL - 2);
+  });
+}
+
+export function exportPMBPNG(canvas: HTMLCanvasElement, payload: PMBPayload): Blob {
+  const dataUrl = canvas.toDataURL('image/png');
+  const [, base64] = dataUrl.split(',');
+  const binary = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  const trailer = new TextEncoder().encode(PMB_TAG + payloadToBase64(payload));
+  const combined = new Uint8Array(binary.length + trailer.length);
+  combined.set(binary, 0);
+  combined.set(trailer, binary.length);
+  return new Blob([combined], { type: 'image/png' });
 }

--- a/spirl-canon/apps/portal/src/lib/registry.ts
+++ b/spirl-canon/apps/portal/src/lib/registry.ts
@@ -1,5 +1,68 @@
-export type Module = { id: string; name: string };
-const modules: Module[] = [{ id: 'mod1', name: 'Module One' }];
-export function listModules() {
+import type { ModuleRecord } from './sqlite/worker';
+
+let worker: Worker | null = null;
+let requestId = 0;
+const pending = new Map<number, (rows: ModuleRecord[]) => void>();
+let cache: ModuleRecord[] | null = null;
+
+function ensureWorker() {
+  if (!worker && typeof window !== 'undefined') {
+    worker = new Worker(new URL('./sqlite/worker.ts', import.meta.url), { type: 'module' });
+    worker.addEventListener('message', (event: MessageEvent<{ type: string; rows: ModuleRecord[]; requestId: number }>) => {
+      const { requestId: id, rows } = event.data;
+      const resolve = pending.get(id);
+      if (resolve) {
+        pending.delete(id);
+        resolve(rows);
+      }
+    });
+  }
+  return worker;
+}
+
+async function loadModulesFromNetwork(): Promise<ModuleRecord[]> {
+  const response = await fetch('/modules.json');
+  const modules = (await response.json()) as ModuleRecord[];
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('spirl.registry', JSON.stringify(modules));
+  }
+  const sqlite = ensureWorker();
+  sqlite?.postMessage({ type: 'init', modules });
   return modules;
 }
+
+export async function loadModules(): Promise<ModuleRecord[]> {
+  if (cache) return cache;
+  if (typeof localStorage !== 'undefined') {
+    const stored = localStorage.getItem('spirl.registry');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as ModuleRecord[];
+        cache = parsed;
+        ensureWorker()?.postMessage({ type: 'init', modules: parsed });
+        return parsed;
+      } catch {
+        // ignore and fetch fresh
+      }
+    }
+  }
+  cache = await loadModulesFromNetwork();
+  return cache;
+}
+
+export async function queryModules(search: string): Promise<ModuleRecord[]> {
+  const sqlite = ensureWorker();
+  const modules = await loadModules();
+  if (!sqlite) {
+    if (!search) return modules;
+    const term = search.toLowerCase();
+    return modules.filter((module) => module.name.toLowerCase().includes(term) || module.id.toLowerCase().includes(term));
+  }
+  return new Promise<ModuleRecord[]>((resolve) => {
+    const id = ++requestId;
+    pending.set(id, resolve);
+    sqlite.postMessage({ type: 'query', sql: 'select * from modules where name like ?', params: [`%${search}%`], requestId: id });
+  });
+}
+
+export type Module = ModuleRecord;

--- a/spirl-canon/apps/portal/src/lib/runtime.ts
+++ b/spirl-canon/apps/portal/src/lib/runtime.ts
@@ -1,5 +1,22 @@
-import { Recipe } from './orchestrator';
+import { ScheduledRecipe } from './orchestrator';
 
-export async function run(recipe: Recipe): Promise<string[]> {
-  return recipe.beads.map(b => `run:${b.moduleId}`);
+export type OperatorLog = { at: number; moduleId: string; detail: string };
+
+export async function run(recipe: ScheduledRecipe): Promise<OperatorLog[]> {
+  const logs: OperatorLog[] = recipe.beads.map((bead) => ({
+    at: bead.tSec ?? recipe.punchWindow.tStartSec,
+    moduleId: bead.moduleId,
+    detail: JSON.stringify(bead.inputs),
+  }));
+  logs.push({
+    at: recipe.punchWindow.tStartSec,
+    moduleId: 'φ-pinch',
+    detail: `Prelude sealed → window ${recipe.punchWindow.tStartSec}s→${recipe.punchWindow.tEndSec}s`,
+  });
+  logs.push({
+    at: recipe.punchWindow.tEndSec,
+    moduleId: 'φ-punch',
+    detail: 'Window released',
+  });
+  return logs.sort((a, b) => a.at - b.at);
 }

--- a/spirl-canon/apps/portal/src/lib/sqlite/worker.ts
+++ b/spirl-canon/apps/portal/src/lib/sqlite/worker.ts
@@ -1,4 +1,46 @@
-self.onmessage = () => {
-  // stub worker
+export type ModuleRecord = {
+  id: string;
+  name: string;
+  description: string;
+  inputs: { name: string; type: string; default?: any }[];
 };
+
+type WorkerRequest =
+  | { type: 'init'; modules: ModuleRecord[] }
+  | { type: 'query'; sql: string; params?: any[]; requestId: number };
+
+type WorkerResponse = { type: 'result'; rows: ModuleRecord[]; requestId: number };
+
+let registry: ModuleRecord[] = [];
+
+self.addEventListener('message', (event: MessageEvent<WorkerRequest>) => {
+  const message = event.data;
+  if (message.type === 'init') {
+    registry = message.modules;
+    return;
+  }
+  if (message.type === 'query') {
+    const rows = runSql(message.sql, message.params ?? []);
+    const response: WorkerResponse = { type: 'result', rows, requestId: message.requestId };
+    (self as unknown as { postMessage: (msg: WorkerResponse) => void }).postMessage(response);
+  }
+});
+
+function runSql(sql: string, params: any[]): ModuleRecord[] {
+  const normalised = sql.trim().toLowerCase();
+  if (normalised.startsWith('select') && normalised.includes('from modules')) {
+    if (normalised.includes('where name like ?')) {
+      const [termRaw] = params;
+      const term = String(termRaw ?? '')
+        .replace(/%/g, '')
+        .toLowerCase();
+      return registry.filter((module) =>
+        module.name.toLowerCase().includes(term) || module.id.toLowerCase().includes(term)
+      );
+    }
+    return registry;
+  }
+  throw new Error(`Unsupported SQL: ${sql}`);
+}
+
 export {};

--- a/spirl-canon/apps/portal/src/styles/globals.css
+++ b/spirl-canon/apps/portal/src/styles/globals.css
@@ -1,1 +1,309 @@
-body { background: #0b0f1a; color: #fff; }
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, sans-serif;
+  background: #0b0f1a;
+  color: #e0e6ff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(58, 75, 122, 0.4), transparent 60%), #0b0f1a;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #5368ff, #f25cff);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.btn.secondary {
+  background: rgba(82, 118, 255, 0.2);
+  border: 1px solid rgba(136, 161, 255, 0.4);
+  color: #cbd8ff;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.home header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.home .cta {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+}
+
+.home .guide {
+  background: rgba(17, 24, 39, 0.65);
+  border: 1px solid rgba(136, 161, 255, 0.18);
+  border-radius: 24px;
+  padding: 1.5rem;
+}
+
+.home .guide ol {
+  padding-left: 1.25rem;
+}
+
+.home .guide li {
+  margin-bottom: 0.75rem;
+}
+
+.home .meta {
+  margin-top: 1.5rem;
+  color: #94a8ff;
+}
+
+.builder {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .builder {
+    grid-template-columns: 320px 320px 1fr;
+    align-items: start;
+  }
+}
+
+.panel {
+  background: rgba(11, 15, 26, 0.85);
+  border: 1px solid rgba(136, 161, 255, 0.18);
+  border-radius: 24px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel header h2 {
+  margin: 0 0 0.5rem;
+}
+
+.panel input,
+.panel label input,
+.panel textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(136, 161, 255, 0.28);
+  background: rgba(20, 28, 46, 0.9);
+  color: #e0e6ff;
+}
+
+.modules ul,
+.beads ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modules li,
+.beads li {
+  background: rgba(20, 28, 46, 0.9);
+  border-radius: 18px;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.modules li button,
+.beads li button {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(82, 118, 255, 0.4);
+  color: #fff;
+  cursor: pointer;
+}
+
+.modules li strong {
+  display: block;
+  font-weight: 600;
+}
+
+.bead-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.inputs {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.inputs label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.panel .empty {
+  text-align: center;
+  padding: 1rem;
+  color: #94a8ff;
+  background: rgba(17, 24, 39, 0.8);
+  border-radius: 16px;
+}
+
+.pmb-encoder {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pmb-encoder header h2 {
+  margin: 0;
+}
+
+.pmb-encoder canvas {
+  width: 100%;
+  max-width: 360px;
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(43, 69, 141, 0.25);
+}
+
+.pmb-encoder .actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pmb-encoder .hint {
+  color: #94a8ff;
+  font-size: 0.9rem;
+}
+
+.operator {
+  background: rgba(20, 28, 46, 0.9);
+  border-radius: 24px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.operator header h2 {
+  margin: 0;
+}
+
+.operator .terminal {
+  background: rgba(11, 15, 26, 0.9);
+  border-radius: 16px;
+  min-height: 120px;
+  padding: 1rem;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+  color: #cbd8ff;
+}
+
+.logs {
+  background: rgba(11, 15, 26, 0.85);
+  border-radius: 18px;
+  padding: 1rem;
+  color: #b8c6ff;
+}
+
+.logs ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.scanner {
+  background: rgba(11, 15, 26, 0.85);
+  border: 1px solid rgba(136, 161, 255, 0.18);
+  border-radius: 24px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.scanner .preview {
+  width: 100%;
+  max-height: 240px;
+  border-radius: 16px;
+  background: rgba(20, 28, 46, 0.9);
+}
+
+.scanner .actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.scanner .btn.file {
+  position: relative;
+  overflow: hidden;
+}
+
+.scanner .btn.file input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.error {
+  color: #ff9fb4;
+}
+
+.results {
+  margin-top: 2rem;
+  background: rgba(11, 15, 26, 0.85);
+  border-radius: 24px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.results pre {
+  background: rgba(20, 28, 46, 0.9);
+  border-radius: 16px;
+  padding: 1rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.page.bundle header {
+  margin-bottom: 1.5rem;
+}
+
+.page.bundle .error {
+  margin-top: 1rem;
+}

--- a/spirl-canon/packages/core/src/pmbAssign.ts
+++ b/spirl-canon/packages/core/src/pmbAssign.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'crypto';
-
 export type PMBPayload = {
   v: 'pmb1';
   id: string;
@@ -15,5 +13,14 @@ export function recipeToPMB(recipe: any, receipt: string): PMBPayload {
 }
 
 function digest(s: string) {
-  return createHash('sha256').update(s).digest('hex').slice(0, 16);
+  // Fowler–Noll–Vo (FNV-1a) inspired hash that works in both Node and browser runtimes.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < s.length; i += 1) {
+    hash ^= s.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  // produce 16 hex chars (64-bit style) by mixing with string length for determinism
+  const mixed = (hash ^ s.length) >>> 0;
+  const hi = ((mixed << 5) ^ (hash >>> 3)) >>> 0;
+  return hi.toString(16).padStart(8, '0') + mixed.toString(16).padStart(8, '0');
 }

--- a/spirl-canon/packages/core/src/pmbGlyph.ts
+++ b/spirl-canon/packages/core/src/pmbGlyph.ts
@@ -1,3 +1,11 @@
-export function phiTicks(count = 89 * 89) {
-  return Array.from({ length: count }, (_, i) => i);
+export type PhiTick = { angleDeg: number; emphasis: boolean };
+
+export function phiTicks(count = 144): PhiTick[] {
+  const ticks: PhiTick[] = [];
+  const goldenAngle = 137.5;
+  for (let i = 0; i < count; i += 1) {
+    const angleDeg = (i * goldenAngle) % 360;
+    ticks.push({ angleDeg, emphasis: i % 5 === 0 });
+  }
+  return ticks;
 }

--- a/spirl-canon/tests/pmb_encode_decode.test.ts
+++ b/spirl-canon/tests/pmb_encode_decode.test.ts
@@ -1,15 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { recipeToPMB } from '../packages/core/src/pmbAssign';
-import { mathReceipt } from '../packages/core/src/receipts';
-import { encodePMB } from '../apps/portal/src/lib/pmb/encode';
-import { decodePMB } from '../apps/portal/src/lib/pmb/decode';
+import { serializePMBPayload } from '../apps/portal/src/lib/pmb/encode';
+import { decodePMBBytes } from '../apps/portal/src/lib/pmb/decode';
 
-describe('pmb encode/decode', () => {
-  it('round trips payload', () => {
-    const recipe = { id: 'r1', name: 'demo', beads: [], punchWindow: { tStartSec: 616, tEndSec: 677 } };
-    const payload = recipeToPMB(recipe, mathReceipt());
-    const buf = encodePMB(payload);
-    const decoded = decodePMB(buf);
+const sampleRecipe = {
+  id: 'demo-recipe',
+  name: 'Rainbow Prelude',
+  beads: [
+    { id: 'b1', moduleId: 'oscillator', inputs: { frequency: 432, waveform: 'sine' } },
+    { id: 'b2', moduleId: 'lattice', inputs: { stages: 3, pattern: '1-1-2-3-5' } },
+  ],
+  punchWindow: { tStartSec: 616, tEndSec: 677 },
+};
+
+describe('PMB encode/decode', () => {
+  it('round-trips a recipe payload through PNG trailer bytes', () => {
+    const payload = recipeToPMB(sampleRecipe, 'α=37.5° | ε₃=0.03934→Δ≈7.08° | θ′(κ=1.12)≈8.35×10⁻⁷ rad | φ-tilt=0°');
+    const pngBytes = serializePMBPayload(payload);
+    const decoded = decodePMBBytes(pngBytes);
     expect(decoded).toEqual(payload);
   });
 });

--- a/spirl-canon/tests/portal_pwa.test.ts
+++ b/spirl-canon/tests/portal_pwa.test.ts
@@ -1,15 +1,32 @@
-import { describe, it, expect } from 'vitest';
-import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 
-describe('portal PWA', () => {
-  const root = path.resolve(__dirname, '../apps/portal/public');
-  it('has manifest', () => {
-    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.webmanifest'), 'utf8'));
+const portalRoot = path.resolve(__dirname, '../apps/portal');
+
+function read(rel: string) {
+  return readFileSync(path.join(portalRoot, rel), 'utf8');
+}
+
+describe('Portal PWA shell', () => {
+  it('ships a manifest with installable metadata', () => {
+    const manifestPath = path.join(portalRoot, 'public/manifest.webmanifest');
+    expect(existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(read('public/manifest.webmanifest'));
     expect(manifest.name).toBe('SP1RL Portal');
+    expect(manifest.display).toBe('standalone');
+    expect(manifest.icons.length).toBeGreaterThanOrEqual(2);
   });
-  it('has service worker', () => {
-    const sw = fs.readFileSync(path.join(root, 'sw.js'), 'utf8');
-    expect(sw).toMatch('self.addEventListener');
+
+  it('provides a cache-first service worker for the operator shell', () => {
+    const sw = read('public/sw.js');
+    expect(sw).toContain("self.addEventListener('install'");
+    expect(sw).toContain("PRECACHE");
+    expect(sw).toContain("'/modules.json'");
+  });
+
+  it('exports static bundles via Next.js export mode', () => {
+    const cfg = read('next.config.mjs');
+    expect(cfg).toContain("output: 'export'");
   });
 });

--- a/spirl-canon/tests/recipe_orchestrator.test.ts
+++ b/spirl-canon/tests/recipe_orchestrator.test.ts
@@ -1,15 +1,26 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { schedule } from '../apps/portal/src/lib/orchestrator';
 
-describe('recipe orchestrator', () => {
-  it('schedules beads and preserves punch window', () => {
-    const recipe = { id: 'r1', name: 'demo', beads: [
-      { id: 'b1', moduleId: 'm1', inputs: {} },
-      { id: 'b2', moduleId: 'm2', inputs: {} },
-    ] };
-    const out = schedule(recipe);
-    expect(out.punchWindow.tStartSec).toBe(616);
-    expect(out.punchWindow.tEndSec).toBe(677);
-    expect(out.beads[0].tSec).toBeLessThan(out.beads[1].tSec);
+const baseRecipe = {
+  id: 'phi-demo',
+  name: 'Phi Pinch',
+  beads: [
+    { id: 'b1', moduleId: 'oscillator', inputs: { frequency: 432 } },
+    { id: 'b2', moduleId: 'lattice', inputs: { pattern: '1-1-2-3-5' } },
+    { id: 'b3', moduleId: 'render', inputs: { quality: 0.8 } },
+  ],
+};
+
+describe('Recipe orchestrator', () => {
+  it('applies φ-pinch scheduling and preserves punch window', () => {
+    const scheduled = schedule(baseRecipe);
+    expect(scheduled.punchWindow.tStartSec).toBe(616);
+    expect(scheduled.punchWindow.tEndSec).toBe(677);
+    const times = scheduled.beads.map((bead) => bead.tSec ?? 0);
+    const sorted = [...times].sort((a, b) => a - b);
+    expect(times).toEqual(sorted);
+    expect(times[0]).toBeGreaterThan(470);
+    expect(times[times.length - 1]).toBeLessThan(scheduled.punchWindow.tStartSec);
+    expect(scheduled.receipt).toContain('α=');
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['packages/**/test/**/*.ts']
+    include: ['packages/**/test/**/*.ts', 'spirl-canon/tests/**/*.ts']
   }
 });


### PR DESCRIPTION
## Summary
- expand the portal app into an installable mobile PWA with service worker registration, quickstart landing page, and bundle shell loader
- add a recipe builder with registry search, phi-pinch scheduling, PMB encoder, scanner, and offline operator panel
- implement deterministic PMB encode/decode utilities with visual grid fallback plus vitest coverage for orchestration, PWA assets, and PMB round-trips

## Testing
- `npx vitest run` *(fails: npm registry 403 in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb16e48108327b82fbb1a9da1f204